### PR TITLE
luarocks not properly parsing md5 hashes from openssl/md5 commands

### DIFF
--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -305,14 +305,14 @@ function get_md5(file, md5sum)
       computed = pipe:read("*a")
       pipe:close()
       if computed then
-         computed = computed:gsub("%s$",""):sub(-32)
+         computed = computed:sub(-33,-2)
       end
    elseif cfg.md5checker == "md5" then
       local pipe = io.popen("md5 "..file)
       computed = pipe:read("*a")
       pipe:close()
       if computed then
-         computed = computed:gsub("%s$",""):sub(-32)
+         computed = computed:sub(-33,-2)
       end
    end
    return computed


### PR DESCRIPTION
My install of luarocks is using openssl to generate md5 hashes for manifest files. I noticed that it was doing this improperly. I noticed this is also an issue when using the md5 command in the same way. It would leave out the first character of the hash and also leave a hanging newline at the end of the string.

My fork fixes this in a way that I think will be compatible across platforms. That is, assuming openssl and md5 always end their out put with a newline (which I believe to be the case).
