### PR TITLE
fs.execute() must have the ability to deliver un-quoted arguments

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -88,6 +88,13 @@ function execute(command, ...)
    assert(type(command) == "string")
 
    for _, arg in ipairs({...}) do
+      if (type(arg) == "table") then
+        if arg[2] then -- should quote
+          arg = fs.Q(arg[1])
+        else -- should not quote
+          arg = arg[1]
+        end
+      end
       assert(type(arg) == "string")
       command = command .. " " .. fs.Q(arg)
    end


### PR DESCRIPTION
The current version of fs.execute() is quoting the arguments after the first parameter which is the command.
This makes it impossible to have un-quoted arguments executed.

For example, 7z does have an overwrite switch that follows the skipping of the already existing files. [more here](http://dotnetperls.com/7-zip-examples)
    7z x test.zip -aos

If we call 
    fs.execute("7z x", "test.zip", "-aos")
the command that will be executed is going to be
    7z x "test.zip" "-aos"
which is far from what we wanted.

The change in the pull request is supposed to allow for that functionality in the following way (while keeping the default behavior):
    fs.execute("7z x", {"test.zip" = true, "-aos" = false})
will produce:
    7z x "test.zip" -aos
