### PR TITLE
Confirm that lfs.chdir("/") works on windows

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -159,8 +159,7 @@ end
 -- a crossplatform way.
 function change_dir_to_root()
    table.insert(dir_stack, lfs.currentdir())
-   -- TODO Does this work on Windows?
-   lfs.chdir("/")
+   lfs.chdir("/")	-- works on Windows too
 end
 
 --- Change working directory to the previous in the dir stack.


### PR DESCRIPTION
lfs.chdir("/") will go to the root of the drive where the current directory is.

That is:

``` lua
lfs.chdir("c:\\temp\\foo\\bar")   -- lfs.currentdir() is c:\temp\foo\bar
lfs.chdir("/")    -- lfs.currentdir() is c:\

lfs.chdir("d:\\some\\other\\drive")   -- lfs.currentdir() is d:\some\other\drive
lfs.chdir("/")    -- lfs.currentdir() is d:\
```
