### PR TITLE
changes string.gfind for string.gmatch

### DIFF
--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -283,7 +283,7 @@ function split_string(str, delim, maxNb)
    local pat = "(.-)" .. delim .. "()"
    local nb = 0
    local lastPos
-   for part, pos in string.gfind(str, pat) do
+   for part, pos in string.gmatch(str, pat) do
       nb = nb + 1
       result[nb] = part
       lastPos = pos


### PR DESCRIPTION
LR 2.0.8 with a version of Lua 5.1 compiled with compatibility disabled fails as there are some deprecated functions still in use. This was the one I came across, didn't look any further yet.
