### PR TITLE
stat takes %Sp not %A on FreeBSD

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -355,7 +355,7 @@ if detected.macosx then
 end
 
 if detected.bsd then
-   defaults.variables.STATFLAG = "-f '%A'"
+   defaults.variables.STATFLAG = "-f '%Sp'"
 end
 
 if detected.linux then


### PR DESCRIPTION
on my FreeBSD 9.0-RELEASE, installing any rock results in 1000s of the following error message:

stat: %A: bad format

This tiny patch fixes the issue by using the correct %Sp format on FreeBSD.
A quick google for man pages indicates this should work correctly on other BSD flavors too.
