### PR TITLE
Ensures that branches are properly fetched if needed

### DIFF
--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -23,12 +23,10 @@ function get_sources(rockspec, extract, dest_dir)
    -- Strip off .git from base name if present
    module = module:gsub("%.git$", "")
    local command = {git_cmd, "clone", "--depth=1", rockspec.source.url, module}
-   local checkout_command
    local tag_or_branch = rockspec.source.tag or rockspec.source.branch
    if tag_or_branch then
       -- ensure the branch (or tag) is available
       table.insert(command, 4, "--branch=" .. tag_or_branch)
-      checkout_command = {git_cmd, "checkout", tag_or_branch}
    end
    local store_dir
    if not dest_dir then
@@ -45,11 +43,6 @@ function get_sources(rockspec, extract, dest_dir)
       return nil, "Failed cloning git repository."
    end
    fs.change_dir(module)
-   if checkout_command then
-      if not fs.execute(unpack(checkout_command)) then
-         return nil, "Failed checking out tag/branch from git repository."
-      end
-   end
    fs.delete(dir.path(store_dir, module, ".git"))
    fs.delete(dir.path(store_dir, module, ".gitignore"))
    fs.pop_dir()


### PR DESCRIPTION
When trying to install a rock that points to a given branch, my friend @ichramm found that in certain cases, `git checkout the_branch` fails because the repository was cloned with "--depth=1" so the branch does not appear in the history. The error message is:

```
error: pathspec 'the_branch' did not match any file(s) known to git.
```

Changing the code so the repository is cloned with _--depth=1 --branch the_branch_ fixes that.

[The docs](http://git-scm.com/docs/git-clone) says that it would work for tags too, but we haven't tested that.

We also found that this bug is related to the git version. On Debian Squeeze (git 1.7.2.5) the bug does not manifest, but with git 1.7.10 (tested in Archlinux and msysgit) the bug appears.
