### PR TITLE
Fix to support Git source tags as well as branches

### DIFF
--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -24,9 +24,6 @@ function get_sources(rockspec, extract, dest_dir)
    module = module:gsub("%.git$", "")
    local command = {git_cmd, "clone", "--depth=1", rockspec.source.url, module}
    local tag_or_branch = rockspec.source.tag or rockspec.source.branch
-   if tag_or_branch then
-      table.insert(command, 4, "--branch=" .. tag_or_branch)
-   end
    local store_dir
    if not dest_dir then
       store_dir = fs.make_temp_dir(name_version)
@@ -43,6 +40,12 @@ function get_sources(rockspec, extract, dest_dir)
       return nil, "Failed cloning git repository."
    end
    fs.change_dir(module)
+   if tag_or_branch then
+      local checkout_command = {git_cmd, "checkout", tag_or_branch}
+      if not fs.execute(unpack(checkout_command)) then
+         return nil, 'Failed to check out the "' .. tag_or_branch ..'" tag or branch.'
+      end
+   end
    fs.delete(dir.path(store_dir, module, ".git"))
    fs.delete(dir.path(store_dir, module, ".gitignore"))
    fs.pop_dir()


### PR DESCRIPTION
Currently, Luarocks does not support Git tags, only branches, because
it's relying on the --branch argument to clone when checking out a
repository. This means that when you pack a source rock that uses a Git
tag, Git resorts to using HEAD if the value set to source.tag in the
rockspec is a tag rather than an actual branch.

A better strategy is to use the `git checkout` command inside the cloned
git repository. This allows you to agnostically use either a tag or a
branch, which seems to be the desired functionality given the
documentation.
