### PR TITLE
Added save_from_table_to_string to persist module

### DIFF
--- a/src/luarocks/persist.lua
+++ b/src/luarocks/persist.lua
@@ -125,25 +125,33 @@ write_table = function(out, tbl, level, field_order)
    out:write("}")
 end
 
+--- Writes a rockspec table to an io-like object.
+-- @param out userdata: a file object, open for writing.
+-- @param tbl table: the table to be written.
+-- @param field_order table: optional prioritization table
+-- @return userdata The file object originally passed in as the `out` parameter.
+local function write_rockspec(out, tbl, field_order)
+   for k, v, sub_order in util.sortedpairs(tbl, field_order) do
+      out:write(k.." = ")
+      write_value(out, v, 0, sub_order)
+      out:write("\n")
+   end
+   return out
+end
+
 --- Save the contents of a table to a string.
 -- Each element of the table is saved as a global assignment.
 -- Only numbers, strings and tables (containing numbers, strings
 -- or other recursively processed tables) are supported.
 -- @param tbl table: the table containing the data to be written
 -- @param field_order table: an optional array indicating the order of top-level fields.
--- @return string or (nil, string): string if successful, or nil and a
--- message in case of errors.
+-- @return string
 function save_from_table_to_string(tbl, field_order)
    local out = {buffer = {}}
    function out:write(data) table.insert(self.buffer, data) end
-   for k, v, sub_order in util.sortedpairs(tbl, field_order) do
-      out:write(k.." = ")
-      write_value(out, v, 0, sub_order)
-      out:write("\n")
-   end
+   write_rockspec(out, tbl, field_order)
    return table.concat(out.buffer)
 end
-
 
 --- Save the contents of a table in a file.
 -- Each element of the table is saved as a global assignment.
@@ -159,7 +167,7 @@ function save_from_table(filename, tbl, field_order)
    if not out then
       return nil, "Cannot create file at "..filename
    end
-   out:write(save_from_table_to_string(tbl, field_order))
+   write_rockspec(out, tbl, field_order)
    out:close()
    return true
 end


### PR DESCRIPTION
This adds the ability to save a rockspec to a string. 

I needed this functionality for a utility that I'm experimenting with and since it was easier to just include in Luarocks itself, I thought I'd see if you were interested in having this change.

If you're interested in it, please let me know if there's anything you want changed/improved before pulling.
