### PR TITLE
Fix mode string in call to io.open

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -247,7 +247,7 @@ function copy(src, dest, perms)
    if not perms then perms = fs.get_permissions(src) end
    local src_h, err = io.open(src, "rb")
    if not src_h then return nil, err end
-   local dest_h, err = io.open(dest, "wb+")
+   local dest_h, err = io.open(dest, "w+b")
    if not dest_h then src_h:close() return nil, err end
    while true do
       local block = src_h:read(8192)


### PR DESCRIPTION
On 5.2, Luarocks fails when installing some rocks with the following
error:

```
invalid mode 'wb+' (should match '[rwa]%+?b?')
```

This does not happen on 5.1; I suspect 5.2 may be stricter about
validating the mode string. The docs for 5.1 suggest the 'b' must always
come at the end:

> The mode string can also have a 'b' at the end
> (http://www.lua.org/manual/5.1/manual.html#pdf-io.open)
