### PR TITLE
Changes MACOSX_DEPLOYMENT_TARGET to 10.5

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -359,8 +359,8 @@ if detected.macosx then
    defaults.external_lib_extension = "dylib"
    defaults.arch = "macosx-"..proc
    defaults.platforms = {"unix", "bsd", "macosx"}
-   defaults.variables.CC = "export MACOSX_DEPLOYMENT_TARGET=10.3; gcc"
-   defaults.variables.LD = "export MACOSX_DEPLOYMENT_TARGET=10.3; gcc"
+   defaults.variables.CC = "export MACOSX_DEPLOYMENT_TARGET=10.5; gcc"
+   defaults.variables.LD = "export MACOSX_DEPLOYMENT_TARGET=10.5; gcc"
    defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
    defaults.variables.STATFLAG = "-f '%A'"
 end


### PR DESCRIPTION
Installing the lsqlite3 package uses the -rpath option to gcc,
which is only valid with a MACOSX_DEPLOYMENT_TARGET of 10.5 or greater.

Without the change, trying `luarocks install lsqlite3` shows:

```
export MACOSX_DEPLOYMENT_TARGET=10.3; gcc -bundle -undefined dynamic_lookup -all_load -o lsqlite3.so -L/usr/local/lib lsqlite3.o -L/usr/local/lib -Wl,-rpath,/usr/local/lib: -lsqlite3
ld: -rpath can only be used when targeting Mac OS X 10.5 or later
```

With this change, lsqlite3 can be successfully installed on OSX.
