### PR TITLE
Add purge.lua to LUAROCKS_FILES in Makefile, and remove duplicate add.lua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build/builtin.lua fetch/cvs.lua fetch/git.lua fetch/sscm.lua tools/patch.lua \
 fetch/svn.lua tools/zip.lua tools/tar.lua pack.lua type_check.lua make.lua path.lua \
 remove.lua fs.lua manif.lua add.lua deps.lua build.lua search.lua show.lua \
 manif_core.lua fetch.lua unpack.lua validate.lua cfg.lua download.lua \
-help.lua util.lua index.lua cache.lua add.lua refresh_cache.lua loader.lua \
+help.lua util.lua index.lua cache.lua refresh_cache.lua loader.lua \
 admin_remove.lua fetch/hg.lua fetch/git_file.lua new_version.lua lint.lua purge.lua
 
 CONFIG_FILE = $(SYSCONFDIR)/config.lua


### PR DESCRIPTION
This fixes "make install". However, "make check_makefile" still fails for me with:

diff makefile_list.txt luarocks_dir.txt
0a1

> /home/rrt/repo/luarocks/src/bin
> 2a4
> rclauncher.c
> 29a32
> /home/rrt/repo/luarocks/src/luarocks
> 49a53
> site_config.lua
> make: **\* [check_makefile] Error 1

It looks like these paths need to be ignored.
