### PR TITLE
Improve support for parallel rocks trees with different Lua versions

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -98,16 +98,18 @@ end
 
 -- Path configuration:
 
+local version_suffix = lua_version:gsub ("%.", "_")
 local sys_config_file, home_config_file
 local sys_config_ok, home_config_ok = false, false
+sys_config_file = site_config["LUAROCKS_SYSCONFIG_" .. version_suffix] or site_config.LUAROCKS_SYSCONFIG
 if detected.windows then
    home = os.getenv("APPDATA") or "c:"
-   sys_config_file = site_config.LUAROCKS_SYSCONFIG or "c:/luarocks/config.lua"
+   sys_config_file = sys_config_file or "c:/luarocks/config.lua"
    home_config_file = home.."/luarocks/config.lua"
    home_tree = home.."/luarocks/"
 else
    home = os.getenv("HOME") or ""
-   sys_config_file = site_config.LUAROCKS_SYSCONFIG or "/etc/luarocks/config.lua"
+   sys_config_file = sys_config_file or "/etc/luarocks/config.lua"
    home_config_file = home.."/.luarocks/config.lua"
    home_tree = home.."/.luarocks/"
 end
@@ -126,7 +128,7 @@ else -- nil or false
 end
 
 if not site_config.LUAROCKS_FORCE_CONFIG then
-   home_config_file = os.getenv("LUAROCKS_CONFIG") or home_config_file
+   home_config_file = os.getenv("LUAROCKS_CONFIG_" .. version_suffix) or os.getenv("LUAROCKS_CONFIG") or home_config_file
    local home_overrides, err = persist.load_into_table(home_config_file, { home = home })
    if home_overrides then
       home_config_ok = true

--- a/src/luarocks/path.lua
+++ b/src/luarocks/path.lua
@@ -37,8 +37,8 @@ end
 function root_dir(rocks_dir)
    assert(type(rocks_dir) == "string")
    
-   local suffix = dir.path("lib", "luarocks", "rocks")
-   return rocks_dir:match("(.*)" .. suffix .. "$")
+   local suffix = dir.path("lib", "luarocks")
+   return rocks_dir:match("(.*)" .. suffix .. ".*$")
 end
 
 function deploy_bin_dir(tree)


### PR DESCRIPTION
Add support for LUAROCKS_SYSCONFIG_X_Y and LUAROCKS_CONFIG_X_Y,
similar to LUA_PATH_5_2, but for any verison of Lua.

Allow repository paths to contain extra components under
"lib/luarocks", so for example you can have "lib/luarocks/5.1/rocks"
and "lib/luarocks/5.2/rocks".

If you're happy with this, I'll document it in the wiki.

The change to the root_dir function is conservative, but unless I misunderstood the code, it seems better to use cfg.root instead of root_dir (cfg.rocks_dir), although this would need another function, like deploy_*_dir, to treat root when it's a table or a string. This would leave only one caller of root_dir, which is do_pack_binary_rock.
