### PR TITLE
optional verbose output 

### DIFF
--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -4,13 +4,22 @@
 -- used by this module.
 module("luarocks.fs.win32.tools", package.seeall)
 
+
+--uncomment following line to make executed commands and results visible 
+--TODO: make commandline option
+--local verbose = true   
+
 local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
 local cfg = require("luarocks.cfg")
 
 local dir_stack = {}
-
+   
 local vars = cfg.variables
+
+local function pack(...) 
+   return { n = select("#", ...), ... } 
+end
 
 --- Strip the last extension of a filename.
 -- Example: "foo.tar.gz" becomes "foo.tar".
@@ -51,8 +60,17 @@ end
 -- @return boolean: true if command succeeds (status code 0), false
 -- otherwise.
 function execute_string(cmd)
-   local code = os.execute(command_at(fs.current_dir(), cmd))
-   if code == 0 or code == true then
+   cmd = command_at(fs.current_dir(), cmd)
+   if verbose then print("Executing: "..tostring(cmd)) end
+   local code = pack(os.execute(cmd))
+   if verbose then
+      print("Results: "..tostring(code.n))
+      for i = 1,code.n do
+         print("  "..tostring(i).." ("..type(code[i]).."): "..tostring(code[i])) 
+      end
+      print()
+   end
+   if code[1] == 0 or code[1] == true then
       return true
    else
       return false
@@ -133,7 +151,8 @@ end
 -- plus an error message.
 function copy_contents(src, dest)
    assert(src and dest)
-   if fs.execute_string(fs.quiet(vars.CP.." -a "..src.."\\*.* "..fs.Q(dest))) then
+   if fs.execute_string(fs.quiet("xcopy "..src.."\\*.* "..fs.Q(dest).." /S/E/Y")) then
+   --if fs.execute_string(fs.quiet(vars.CP.." -a "..src.."\\*.* "..fs.Q(dest))) then
       return true
    else
       return false, "Failed copying "..src.." to "..dest


### PR DESCRIPTION
I found myself repeatedly making those changes, so added them (disabled) so only enabling is only uncommenting a line.

TODO: add to unix as well and make a commandline option `--verbose`
