### PR TITLE
bug in builtin.lua that caused a previous "ok=false" to be reset in a la...

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -230,12 +230,14 @@ function run(rockspec)
          end
       end
    end
-   for name, dest in pairs(built_modules) do
-      fs.make_dir(dest)
-      ok = fs.copy(name, dest)
-      if not ok then
-         err = "Failed installing "..name.." in "..dest
-         break
+   if ok then
+      for name, dest in pairs(built_modules) do
+         fs.make_dir(dest)
+         ok = fs.copy(name, dest)
+         if not ok then
+            err = "Failed installing "..name.." in "..dest
+            break
+         end
       end
    end
    if ok then


### PR DESCRIPTION
...ter stage of building and hence report success even though it had errors.
