### PR TITLE
Remove unwanted output

### DIFF
--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -269,10 +269,11 @@ function download(url, filename)
    if cfg.downloader == "wget" then
       local wget_cmd = vars.WGET.." --no-check-certificate --no-cache --user-agent=\""..cfg.user_agent.." via wget\" --quiet --continue "
       if filename then
-         return fs.execute(wget_cmd.." --output-document ", filename, url)
+         wget_cmd = wget_cmd.." --output-document "..fs.Q(filename).." "..fs.Q(url)
       else
-         return fs.execute(wget_cmd, url)
+         wget_cmd = wget_cmd.." "..fs.Q(url)
       end
+      return fs.execute(wget_cmd.." 2> NUL 1> NUL")
    elseif cfg.downloader == "curl" then
       filename = filename or dir.base_name(url)
       return fs.execute_string(vars.CURL.." -L --user-agent \""..cfg.user_agent.." via curl\" "..fs.Q(url).." 2> NUL 1> "..fs.Q(filename))


### PR DESCRIPTION
A LuaRocks download action on windows would cause `wget` to display some unwanted stuff. Example:

```
C:\Users\Thijs>luarocks search usb
SYSTEM_WGETRC = c:/progra~1/wget/etc/wgetrc
syswgetrc = c:/progra~1/wget/etc/wgetrc

Search results:
===============


C:\Users\Thijs>
```

This fixes the output to not display the first 2 lines above
