### PR TITLE
When you supply an existing Lua installation, the suggested value for LU...

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -643,7 +643,7 @@ print(S[[
  You may want to add the following elements to your paths;
 PATH     :   $LUA_BINDIR;$FULL_PREFIX
 LUA_PATH :   $ROCKS_TREE\share\lua\$LUA_VERSION\?.lua;$ROCKS_TREE\share\lua\$LUA_VERSION\?\init.lua
-LUA_CPATH:   $LUA_LIBDIR\lua\$LUA_VERSION\?.dll
+LUA_CPATH:   $ROCKS_TREE\lib\lua\$LUA_VERSION\?.dll
 
 ]])
 os.exit(0)


### PR DESCRIPTION
When you supply an existing Lua installation, the suggested value for LUA_CPATH is wrong.

``` sh
install /P c:\LuaRocks /LUA d:\trunk_git\packages\Lua5.1 /F

(...)

 You may want to add the following elements to your paths;
PATH     :   d:\trunk_git\packages\Lua5.1\bin\;c:\LuaRocks\2.1
LUA_PATH :
c:\LuaRocks\share\lua\5.1\?.lua;c:\LuaRocks\share\lua\5.1\?\init.lua
LUA_CPATH:   d:\trunk_git\packages\Lua5.1\lib\lua\5.1\?.dll
```

Even `luarocks path` shows the correct values:

``` sh
SET LUA_CPATH=c:\LuaRocks/lib/lua/5.1/?.dll;c:\LuaRocks\lib\lua\5.1\?.dll
```
