### PR TITLE
Win32 escapes

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -42,18 +42,6 @@ function Q(arg)
    return "'" .. arg:gsub("'", "'\\''") .. "'"
 end
 
---- Quote argument for shell processing in batch files/scripts.
--- By default calls fs.Q()
--- @param arg string: Unquoted argument.
--- @return string: Quoted argument.
-function Qb(arg)
-   assert(type(arg) == "string")
-
-   -- only strange platforms (aka Windows) need special
-   -- escape handling for scripts/batch files
-   return fs.Q(arg)
-end
-
 --- Test is file/dir is writable.
 -- Warning: testing if a file/dir is writable does not guarantee
 -- that it will remain writable and therefore it is no replacement


### PR DESCRIPTION
This should provide better escaping on Windows, in particular for embedded environment variables (e.g. `%CD%`) and backslashes at the end of the argument (or immediately before an embedded double quote).
