### PR TITLE
Fixed windows installer argument handling

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -65,9 +65,10 @@ local function print_help()
 	print(S[[
 Installs LuaRocks.
 
-/P [dir]       (REQUIRED) Where to install. 
-               Note that version; $VERSION, will be
-               appended to this path.
+/P [dir]       (REQUIRED) Where to install LuaRocks. 
+               Note that version; $VERSION, will be appended to this
+               path, so "/P c:\luarocks\" will install in 
+               "c:\luarocks\$VERSION\"
 
 Configuring the destinations:
 /TREE [dir]    Root of the local tree of installed rocks.


### PR DESCRIPTION
If the installer is given arguments with spaces, or double quotes, it fails with an error.

Mostly because in `install /P "c:\program files\LuaRocks\"` the trailing `\` is an escape sequence, turning the closing `"` into a literal.

also;
- whitespace fixes
- uppercase fix
- updating help text displayed
