### PR TITLE
Search system path for Lua install instead of ancient defaults

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -696,7 +696,7 @@ if REGISTRY then
 	print()
 	print([[Loading registry information for ".rockspec" files]])
 	exec( S[[lua5.1\bin\lua5.1.exe "$FULL_PREFIX\LuaRocks.reg.lua" "$FULL_PREFIX\LuaRocks.reg.template"]] )
-	exec( S"$FULL_PREFIX\\LuaRocks.reg" )
+	exec( S[["$FULL_PREFIX\\LuaRocks.reg"]] )
 end
 
 -- ***********************************************************


### PR DESCRIPTION
1) will search the system path for Lua interpreter. If no location is found, only then the ancient defaults will be checked.
2) if `/LUA` is provided, it will only look there, and fail if not found instead of falling back to the defaults
3) if no interpreter found, it is not automatically installed. Only with explicit `/L` switch the included interpreter is installed
