### PR TITLE
Improved debug/verbose output

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -709,6 +709,7 @@ rocks_trees = {
 	end
 	f:write(S"    LUALIB = '$LUA_LIBNAME'\n")
 	f:write("}\n")
+	f:write("verbose = false   -- set to 'true' to enable verbose output\n")
 	f:close()
 	print(S"Created LuaRocks config file: $CONFIG_FILE")
 else

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -106,6 +106,7 @@ end
 
 --- Run the given command, quoting its arguments, silencing its output.
 -- The command is executed in the current directory in the dir stack.
+-- Silencing is omitted if 'verbose' mode is enabled.
 -- @param command string: The command to be executed. No quoting/escaping
 -- is applied.
 -- @param ... Strings containing additional arguments, which will be quoted.
@@ -113,7 +114,7 @@ end
 -- otherwise.
 function execute_quiet(command, ...)
    assert(type(command) == "string")
-   if cfg.verbose then 
+   if cfg.verbose then -- omit silencing output
       return fs.execute_string(quote_args(command, ...))
    else
       return fs.execute_string(fs.quiet(quote_args(command, ...)))
@@ -150,7 +151,6 @@ if lfs_ok then
 -- @return boolean: true if command succeeds (status code 0), false
 -- otherwise.
 function execute_string(cmd)
-   if cfg.verbose then print("Executing: "..cmd) end
    local code = os.execute(cmd)
    return (code == 0 or code == true)
 end

--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -12,10 +12,6 @@ local dir_stack = {}
 
 local vars = cfg.variables
 
-local function pack(...)
-   return { n = select("#", ...), ... }
-end
-
 --- Strip the last extension of a filename.
 -- Example: "foo.tar.gz" becomes "foo.tar".
 -- If filename has no dots, returns it unchanged.
@@ -60,16 +56,8 @@ end
 -- otherwise.
 function execute_string(cmd)
    cmd = command_at(fs.current_dir(), cmd)
-   if cfg.verbose then print("Executing: "..tostring(cmd)) end
-   local code = pack(os.execute(cmd))
-   if cfg.verbose then
-      print("Results: "..tostring(code.n))
-      for i = 1,code.n do
-         print("  "..tostring(i).." ("..type(code[i]).."): "..tostring(code[i]))
-      end
-      print()
-   end
-   if code[1] == 0 or code[1] == true then
+   local code = os.execute(cmd)
+   if code == 0 or code == true then
       return true
    else
       return false


### PR DESCRIPTION
refactored debug output. Now all is set by using `verbose = true` in the config file instead of manually uncommenting code.

Also moved to platform independent code, from Windows only
