### PR TITLE
Add a configuration option to specify manually installed rocks (#177)

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -265,6 +265,8 @@ local defaults = {
       lib = "lib",
       include = "include"
    },
+
+   rocks_provided = {}
 }
 
 if detected.windows then
@@ -453,6 +455,24 @@ defaults.variables.OBJ_EXTENSION = defaults.obj_extension
 defaults.variables.LUAROCKS_PREFIX = site_config.LUAROCKS_PREFIX
 defaults.variables.LUA = site_config.LUA_DIR_SET and (defaults.variables.LUA_BINDIR.."/"..defaults.lua_interpreter) or defaults.lua_interpreter
 
+-- Add built-in modules to rocks_provided
+defaults.rocks_provided["lua"] = lua_version.."-1"
+
+if lua_version >= "5.2" then
+   -- Lua 5.2+
+   defaults.rocks_provided["bit32"] = lua_version.."-1"
+end
+
+if package.loaded.jit then
+   -- LuaJIT
+   local lj_version = package.loaded.jit.version:match("LuaJIT (%d%.%d%.%d)")
+   defaults.rocks_provided["luajit"] = lj_version.."-1"
+   defaults.rocks_provided["jit"] = lj_version.."-1"
+   defaults.rocks_provided["ffi"] = lj_version.."-1"
+   defaults.rocks_provided["bit"] = lj_version.."-1"
+   defaults.rocks_provided["luabitop"] = lj_version.."-1"
+end
+
 -- Use defaults:
 
 -- Populate values from 'defaults.variables' in 'variables' if they were not
@@ -463,6 +483,17 @@ end
 for k,v in pairs(defaults.variables) do
    if not _M.variables[k] then
       _M.variables[k] = v
+   end
+end
+
+-- Populate values from 'defaults.rocks_provided' in 'rocks_provided' if they
+-- were not already set by user.
+if not type(_M.rocks_provided) == "table" then
+   _M.rocks_provided = {}
+end
+for k,v in pairs(defaults.rocks_provided) do
+   if not _M.rocks_provided[k] then
+      _M.rocks_provided[k] = v
    end
 end
 

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -209,6 +209,12 @@ function search_repos(query)
          end
       end
    end
+   -- search through rocks in cfg.rocks_provided
+   local provided_repo = "built-in or listed in cfg.rocks_provided"
+   local name, versions
+   for name, versions in pairs(cfg.rocks_provided) do
+      store_if_match(results, provided_repo, name, versions, "installed", query)
+   end
    return results
 end
 
@@ -273,6 +279,12 @@ function find_suitable_rock(query)
    if not first then
       return nil, "No results matching query were found."
    elseif not next(results, first) then
+      if cfg.rocks_provided[query.name] ~= nil then
+         -- do not install versions that listed in cfg.rocks_provided
+         return nil, "The found rock "..query.name..
+                     " "..cfg.rocks_provided[query.name]..
+                     " is either built-in or listed in cfg.rocks_provided!"
+      end
       return pick_latest_version(query.name, results[first])
    else
       return results


### PR DESCRIPTION
The patch adds a new configuration option - cfg.rocks_provided.
This option contains a list of packages that are either builtin or
manually installed outside of LuaRocks package management system:

```
rocks_provided = {
  [module_name] = module_version.."-"..rockspec_version,
  -- ...
}
```

These settings are taken into account during dependency resolution
and when search and install commands are used. An attempt to install
a rock from the list causes an error.

LuaRocks automatically adds following modules to the list:

```
rocks_provided = {
   lua = lua_version.."-1",

   -- For Lua 5.2 or later:
   bit32 = lua_version.."-1",

   -- For LuaJIT:
   luajit = lj_version.."-1",
   jit = lj_version.."-1",
   ffi = lj_version.."-1",
   bit = lj_version.."-1",
   luabitop = lj_version.."-1"
}
```

where lua_version extracted from _VERSION (e.g. 5.2),
      lj_version extracted from jit.version (e.g. 2.0.2).

Built-in values can be overridden by configuration options.

Closes #177.
