### PR TITLE
Fixed an improper error message

### DIFF
--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -1,4 +1,3 @@
-
 --- Type-checking functions.
 -- Functions and definitions for doing a basic lint check on files
 -- loaded by LuaRocks.
@@ -183,7 +182,9 @@ local function type_check_item(name, item, expected, context)
          return nil, "Type mismatch on field "..context..name..": expected a string"
       end
       if expected ~= "string" then
-         if not item:match("^"..expected.."$") then
+         if item_type ~= "string" then
+            return nil, "Type mismatch on field "..context..name..": expected a string, got a "..type(item)
+         elseif not item:match("^"..expected.."$") then
             return nil, "Type mismatch on field "..context..name..": invalid value "..item.." does not match '"..expected.."'"
          end
       end


### PR DESCRIPTION
Forgot to check that type=="string" before doing pattern matching on a field content.

Was triggered when version was provided as a string in a luarock.
