### PR TITLE
Fix: Purge command did not check permission for the tree to operate on

### DIFF
--- a/src/luarocks/purge.lua
+++ b/src/luarocks/purge.lua
@@ -44,6 +44,10 @@ function run(...)
    if not fs.is_dir(tree) then
       return nil, "Directory not found: "..tree
    end
+
+   local ok, err = fs.check_command_permissions(flags)
+   if not ok then return nil, err, cfg.errorcodes.PERMISSIONDENIED end
+
    search.manifest_search(results, path.rocks_dir(tree), query)
 
    local sort = function(a,b) return deps.compare_versions(b,a) end


### PR DESCRIPTION
it returned just a long list of failures. Now it properly checks permissions before trying.
