### PR TITLE
Misplaced quote in resulting luarocks.bat file

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -696,7 +696,7 @@ for _, c in ipairs{"luarocks", "luarocks-admin"} do
 SETLOCAL
 SET "LUA_PATH=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH%"
 IF NOT "%LUA_PATH_5_2%"=="" (
-   "SET LUA_PATH_5_2=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_2%"
+   SET "LUA_PATH_5_2=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_2%"
 )
 SET "PATH=$BINDIR;%PATH%"
 "$LUA_INTERPRETER" "$BINDIR\]]..c..[[.lua" %*


### PR DESCRIPTION
Line 699 is writing this in the .bat file.

```
C:\luarocks\2.1>IF NOT "c:\luarocks52\share\lua\5.2\?.lua;c:\luarocks52\share\lua\5.2\?\init.lua;;" == "" ("SET LUA_PATH_5_2=c:\luarocks\2.1\lua\?.lua;c:\luarocks\2.1\lua\?\init.lua;c:\luarocks52\share\lua\5.2\?.lua;c:\luarocks52\share\lua\5.2\?\init.lua;;")
```

Which prints an error: `The system cannot find the path specified.`

It only happens if env var LUA_PATH_5_2 has some value.
