### PR TITLE
Added nil check for tsfd in http_request()

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -611,8 +611,10 @@ local function http_request(url, http, cached)
    if result then
       if cached and headers["last-modified"] then
          local tsfd = io.open(cached..".timestamp", "w")
-         tsfd:write(headers["last-modified"])
-         tsfd:close()
+         if tsfd then
+            tsfd:write(headers["last-modified"])
+            tsfd:close()
+         end
       end
       return table.concat(result)
    else


### PR DESCRIPTION
If the opening of the cache timestamp file fails, then
tsfd would be nil.  write is then invoked on it yielding:

  /usr/local/share/lua/5.1/luarocks/fs/lua.lua:592: attempt to index local 'tsfd' (a nil value)

This changeset simply adds the check for nil.  It does no further error
reporting, so luarocks doesn't crash, but it also doesn't report that the
cache was not updated nor that anything out of the ordinary happened.

---

I ran into this because my cachefile directory was owned by root.  In my private versionI had captured the  error value and output it stderr.  I wasn't sure how luarocks propogates things like that so I left the patch simple.  If you let me know what you prefer, I'll update it.
