### PR TITLE
handle implict subdirectories when unpacking with LuaZip

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -499,9 +499,12 @@ function fs_lua.unzip(zipfile)
          if not ok then return nil, err end
       else
          local base = dir.dir_name(file.filename)
-         if base ~= "" and not fs.is_dir(base) then
-            local ok, err = fs.make_dir(dir.path(fs.current_dir(), base))
-            if not ok then return nil, err end
+         if base ~= "" then
+            base = dir.path(fs.current_dir(), base)
+            if not fs.is_dir(base) then
+               local ok, err = fs.make_dir(base)
+               if not ok then return nil, err end
+            end
          end
          local rf, err = zipfile:open(file.filename)
          if not rf then zipfile:close(); return nil, err end


### PR DESCRIPTION
Create base directories for extracted files even if not explicitly listed in the zipfile. Improves compatibility with `unzip` utility, and fixes luajson issue. Tested only on Linux ...
