### PR TITLE
prepare luarocks for lua 5.3

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ system's package manager.
 --rocks-tree=DIR            Root of the local tree of installed rocks.
                             Default is \$PREFIX
 
---lua-version=VERSION       Use specific Lua version: 5.1 or 5.2
+--lua-version=VERSION       Use specific Lua version: 5.1, 5.2, or 5.3
                             Default is "$LUA_VERSION"
 --lua-suffix=SUFFIX         Versioning suffix to use in Lua filenames.
                             Default is "$LUA_SUFFIX" (lua$LUA_SUFFIX...)
@@ -177,7 +177,7 @@ do
    --lua-version)
       [ -n "$value" ] || die "Missing value in flag $key."
       LUA_VERSION="$value"
-      [ "$LUA_VERSION" = "5.1" -o "$LUA_VERSION" = "5.2" ] || die "Invalid Lua version in flag $key."
+      [ "$LUA_VERSION" = "5.1" -o "$LUA_VERSION" = "5.2" -o "$LUA_VERSION" = "5.3" ] || die "Invalid Lua version in flag $key."
       LUA_VERSION_SET=yes
       ;;
    --with-lua)
@@ -234,7 +234,7 @@ fi
 
 detect_lua_version() {
    detected_lua=`$1 -e 'print(_VERSION:sub(5))' 2> /dev/null`
-   if [ "$detected_lua" = "5.1" -o "$detected_lua" = "5.2" ]
+   if [ "$detected_lua" = "5.1" -o "$detected_lua" = "5.2" -o "$detected_lua" = "5.3" ]
    then
       echo "Lua version detected: $detected_lua"
       if [ "$LUA_VERSION_SET" != "yes" ]
@@ -275,8 +275,11 @@ then
    elif [ "$LUA_VERSION_SET" = "yes" -a "$LUA_VERSION" = "5.2" ]
    then
       suffixes="5.2 52 -5.2 -52"
+   elif [ "$LUA_VERSION_SET" = "yes" -a "$LUA_VERSION" = "5.3" ]
+   then
+      suffixes="5.3 53 -5.3 -53"
    else
-      suffixes="5.2 52 -5.2 -52 5.1 51 -5.1 -51"
+      suffixes="5.3 53 -5.3 -53 5.2 52 -5.2 -52 5.1 51 -5.1 -51"
    fi
    for suffix in `echo $suffixes` ""
    do
@@ -371,12 +374,14 @@ else
    die "Could not determine processor architecture. 'uname -m' failed."
 fi
 
-if [ "$LUA_VERSION" = "5.2" ]
-then
-   LUA_OTHER_VERSION=5.1
-else
-   LUA_OTHER_VERSION=5.2
-fi
+for v in 5.1 5.2 5.3; do
+  if [ "$v" != "$LUA_VERSION" ]; then
+    if [ -e "$PREFIX/share/lua/$v/luarocks/site_config.lua" ]; then
+      LUA_OTHER_VERSION="$v"
+      break
+    fi
+  fi
+done
 
 LUAROCKS_ROCKS_SUBDIR=/lib/luarocks/rocks
 if [ "$VERSIONED_ROCKS_DIR" = "yes" ]
@@ -388,7 +393,7 @@ then
    echo "Existing installation detected."
    LUAROCKS_ROCKS_SUBDIR=`grep "LUAROCKS_ROCKS_SUBDIR" "$PREFIX/share/lua/$LUA_VERSION/luarocks/site_config.lua" | sed 's,.*=\[\[\(.*\)\]\],\1,'`
    echo "Using previously configured rocks dir: $PREFIX$LUAROCKS_ROCKS_SUBDIR"
-elif [ -e "$PREFIX/share/lua/$LUA_OTHER_VERSION/luarocks/site_config.lua" ]
+elif [ -n "$LUA_OTHER_VERSION" ]
 then
    echo "Existing installation detected for other Lua version ($LUA_OTHER_VERSION)."
    LUAROCKS_ROCKS_SUBDIR=$LUAROCKS_ROCKS_SUBDIR-$LUA_VERSION

--- a/install.bat
+++ b/install.bat
@@ -138,7 +138,7 @@ Configuring the destinations:
                if you create a self contained installation.
                
 Configuring the Lua interpreter:
-/LV [version]  Lua version to use; either 5.1 or 5.2.
+/LV [version]  Lua version to use; either 5.1, 5.2, or 5.3.
                Default is 5.1
 /LUA [dir]     Location where Lua is installed - e.g. c:\lua\5.1\
                If not provided, the installer will search the system
@@ -249,8 +249,10 @@ local function check_flags()
 	if vars.LUA_VERSION ~= "5.1" then
 		if vars.LUA_VERSION == "5.2" then
 			vars.LUA_LIB_NAMES = vars.LUA_LIB_NAMES:gsub("5([%.]?)1", "5%12")
+		elseif vars.LUA_VERSION == "5.3" then
+			vars.LUA_LIB_NAMES = vars.LUA_LIB_NAMES:gsub("5([%.]?)1", "5%13")
 		else
-			die("Bad argument: /LV must either be 5.1 or 5.2")
+			die("Bad argument: /LV must either be 5.1, 5.2, or 5.3")
 		end
 	end
 end
@@ -700,6 +702,9 @@ SETLOCAL
 SET "LUA_PATH=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH%"
 IF NOT "%LUA_PATH_5_2%"=="" (
    SET "LUA_PATH_5_2=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_2%"
+)
+IF NOT "%LUA_PATH_5_3%"=="" (
+   SET "LUA_PATH_5_3=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_3%"
 )
 SET "PATH=$BINDIR;%PATH%"
 "$LUA_INTERPRETER" "$BINDIR\]]..c..[[.lua" %*

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -483,6 +483,11 @@ if cfg.lua_version >= "5.2" then
    defaults.rocks_provided["bit32"] = cfg.lua_version.."-1"
 end
 
+if cfg.lua_version >= "5.3" then
+   -- Lua 5.3+
+   defaults.rocks_provided["utf8"] = cfg.lua_version.."-1"
+end
+
 if package.loaded.jit then
    -- LuaJIT
    local lj_version = package.loaded.jit.version:match("LuaJIT (.*)"):gsub("%-","")

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -321,7 +321,7 @@ function util.sortedpairs(tbl, sort_function)
 end
 
 function util.lua_versions()
-   local versions = { "5.1", "5.2" }
+   local versions = { "5.1", "5.2", "5.3" }
    local i = 0
    return function()
       i = i + 1

--- a/src/luarocks/write_rockspec.lua
+++ b/src/luarocks/write_rockspec.lua
@@ -31,8 +31,8 @@ rockspec, and is not guaranteed to be complete or correct.
 --summary="<txt>"     A short one-line description summary.
 --description="<txt>" A longer description string.
 --homepage=<url>      Project homepage.
---lua-version=<ver>   Supported Lua versions. Accepted values are "5.1", "5.2"
-                      or "5.1,5.2".
+--lua-version=<ver>   Supported Lua versions. Accepted values are "5.1", "5.2",
+                      "5.3", "5.1,5.2", "5.2,5.3", or "5.1,5.2,5.3".
 --tag=<tag>           Tag to use. Will attempt to extract version number from it.
 --lib=<lib>[,<lib>]   A comma-separated list of libraries that C files need to
                       link to.
@@ -63,8 +63,14 @@ local function configure_lua_version(rockspec, luaver)
       table.insert(rockspec.dependencies, "lua ~> 5.1")
    elseif luaver == "5.2" then
       table.insert(rockspec.dependencies, "lua ~> 5.2")
+   elseif luaver == "5.3" then
+      table.insert(rockspec.dependencies, "lua ~> 5.3")
    elseif luaver == "5.1,5.2" then
       table.insert(rockspec.dependencies, "lua >= 5.1, < 5.3")
+   elseif luaver == "5.2,5.3" then
+      table.insert(rockspec.dependencies, "lua >= 5.2, < 5.4")
+   elseif luaver == "5.1,5.2,5.3" then
+      table.insert(rockspec.dependencies, "lua >= 5.1, < 5.4")
    else
       util.warning("Please specify supported Lua version with --lua-version=<ver>. "..util.see_help("write_rockspec"))
    end


### PR DESCRIPTION
I don't know if I missed something, but I can install LuaRocks for Lua 5.3, and install/search/list/remove compatible rocks from my own local rocks "server". Only tested on Linux so far.
