### PR TITLE
run LR itself on the Lua interpreter found during install (Windows)

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -707,7 +707,7 @@ IF NOT "%LUA_PATH_5_3%"=="" (
    SET "LUA_PATH_5_3=$LUADIR\?.lua;$LUADIR\?\init.lua;%LUA_PATH_5_3%"
 )
 SET "PATH=$BINDIR;%PATH%"
-"$LUA_INTERPRETER" "$BINDIR\]]..c..[[.lua" %*
+"$LUA_BINDIR\$LUA_INTERPRETER" "$BINDIR\]]..c..[[.lua" %*
 IF NOT "%ERRORLEVEL%"=="2" GOTO EXITLR
 
 REM Permission denied error, try and auto elevate...


### PR DESCRIPTION
run LR itself on the Lua interpreter found during install, not on the interpreter first in the system path. Lining up with the unix shell scripts.
See this comment https://github.com/keplerproject/luarocks/pull/243#discussion_r10999753 
