### PR TITLE
Fix curl --connect-timeout option

### DIFF
--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -264,7 +264,7 @@ function tools.download(url, filename, cache)
    elseif cfg.downloader == "curl" then
       local curl_cmd = fs.Q(vars.CURL).." -f -k -L --user-agent '"..cfg.user_agent.." via curl' "
       if cfg.connection_timeout and cfg.connection_timeout > 0 then
-        curl_cmd = curl_cmd .. "--connect-timeout="..tonumber(cfg.connection_timeout).." " 
+        curl_cmd = curl_cmd .. "--connect-timeout "..tonumber(cfg.connection_timeout).." " 
       end
       ok = fs.execute_string(curl_cmd..fs.Q(url).." 2> /dev/null 1> "..fs.Q(filename))
    end


### PR DESCRIPTION
curl expects options and their arguments to be separate by space
instead of ‘=‘
