### PR TITLE
Create static libraries

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -50,7 +50,7 @@ end
 -- nil and an error message otherwise.
 function builtin.run(rockspec)
    assert(type(rockspec) == "table")
-   local compile_object, compile_library, compile_wrapper_binary --TODO EXEWRAPPER
+   local compile_object, compile_library, compile_static_library, compile_wrapper_binary --TODO EXEWRAPPER
 
    local build = rockspec.build
    local variables = rockspec.variables
@@ -81,6 +81,13 @@ function builtin.run(rockspec)
          extras[#extras+1] = dir.path(variables.LUA_LIBDIR, variables.LUALIB)
          extras[#extras+1] = "-l" .. (variables.MSVCRT or "m")
          local ok = execute(variables.LD.." "..variables.LIBFLAG, "-o", library, unpack(extras))
+         return ok
+      end
+      compile_static_library = function(library, objects, libraries, libdirs, name)
+         local ok = execute(variables.AR, "rc", library, unpack(objects))
+         if ok then
+            ok = execute(variables.RANLIB, library)
+         end
          return ok
       end
       compile_wrapper_binary = function(fullname, name)
@@ -129,6 +136,10 @@ function builtin.run(rockspec)
          end
          return ok
       end
+      compile_static_library = function(library, objects, libraries, libdirs, name)
+         local ok = execute(variables.AR, "-out:"..library, unpack(objects))
+         return ok
+      end
       compile_wrapper_binary = function(fullname, name)
          --TODO EXEWRAPPER
          local fullbasename = fullname:gsub("%.lua$", ""):gsub("/", "\\")
@@ -169,6 +180,13 @@ function builtin.run(rockspec)
             add_flags(extras, "-l%s", {"lua"})
          end
          return execute(variables.LD.." "..variables.LIBFLAG, "-o", library, "-L"..variables.LUA_LIBDIR, unpack(extras))
+      end
+      compile_static_library = function(library, objects, libraries, libdirs, name)
+         local ok = execute(variables.AR, "rc", library, unpack(objects))
+         if ok then
+            ok = execute(variables.RANLIB, library)
+         end
+         return ok
       end
       compile_wrapper_binary = function(fullname, name) return true, name end
       --TODO EXEWRAPPER
@@ -245,6 +263,15 @@ function builtin.run(rockspec)
          ok = compile_library(module_name, objects, info.libraries, info.libdirs, name)
          if not ok then
             return nil, "Failed compiling module "..module_name
+         end
+         module_name = name:match("([^.]*)$").."."..util.matchquote(cfg.static_lib_extension)
+         if moddir ~= "" then
+            module_name = dir.path(moddir, module_name)
+         end
+         built_modules[module_name] = dir.path(libdir, module_name)
+         ok = compile_static_library(module_name, objects, info.libraries, info.libdirs, name)
+         if not ok then
+            return nil, "Failed compiling static library "..module_name
          end
       end
    end

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -233,6 +233,8 @@ local defaults = {
       MAKE = "make",
       CC = "cc",
       LD = "ld",
+      AR = "ar",
+      RANLIB = "ranlib",
 
       CVS = "cvs",
       GIT = "git",
@@ -298,6 +300,7 @@ if detected.windows then
    defaults.platforms = {"win32", "windows" }
    defaults.lib_extension = "dll"
    defaults.external_lib_extension = "dll"
+   defaults.static_lib_extension = "lib"
    defaults.obj_extension = "obj"
    defaults.external_deps_dirs = { "c:/external/" }
    defaults.variables.LUA_BINDIR = site_config.LUA_BINDIR and site_config.LUA_BINDIR:gsub("\\", "/") or "c:/lua"..cfg.lua_version.."/bin"
@@ -311,6 +314,7 @@ if detected.windows then
    defaults.variables.WRAPPER = full_prefix.."\\rclauncher.c"
    defaults.variables.LD = "link"
    defaults.variables.MT = "mt"
+   defaults.variables.AR = "lib"
    defaults.variables.LUALIB = "lua"..cfg.lua_version..".lib"
    defaults.variables.CFLAGS = "/MD /O2"
    defaults.variables.LIBFLAG = "/dll"
@@ -351,11 +355,14 @@ end
 if detected.mingw32 then
    defaults.platforms = { "win32", "mingw32", "windows" }
    defaults.obj_extension = "o"
+   defaults.static_lib_extension = "a"
    defaults.cmake_generator = "MinGW Makefiles"
    defaults.variables.MAKE = "mingw32-make"
    defaults.variables.CC = "mingw32-gcc"
    defaults.variables.RC = "windres"
    defaults.variables.LD = "mingw32-gcc"
+   defaults.variables.AR = "mingw32-gcc-ar"
+   defaults.variables.RANLIB = "mingw32-gcc-ranlib"
    defaults.variables.CFLAGS = "-O2"
    defaults.variables.LIBFLAG = "-shared"
    defaults.external_deps_patterns = {
@@ -375,6 +382,7 @@ end
 
 if detected.unix then
    defaults.lib_extension = "so"
+   defaults.static_lib_extension = "a"
    defaults.external_lib_extension = "so"
    defaults.obj_extension = "o"
    defaults.external_deps_dirs = { "/usr/local", "/usr" }

--- a/src/luarocks/path.lua
+++ b/src/luarocks/path.lua
@@ -251,6 +251,11 @@ function path.path_to_module(file)
       name = file:match("(.*)%."..cfg.lib_extension.."$")
       if name then
          name = name:gsub(dir.separator, ".")
+      else
+         name = file:match("(.*)%."..cfg.static_lib_extension.."$")
+         if name then
+            name = name:gsub(dir.separator, ".")
+         end
       end
    end
    if not name then name = file end


### PR DESCRIPTION
Create static libraries (see #262) when using "builtin" build mode. Seems to work on Linux, Windows/MinGW, and Windows/VC (I haven't tested linking to the generated static libraries yet ...).

Currently no include files are generated ...
