### PR TITLE
Default to a higher minimum OS X version.

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -440,8 +440,8 @@ if detected.macosx then
    defaults.variables.STATFLAG = "-f '%A'"
    local version = io.popen("sw_vers -productVersion"):read("*l")
    version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
-   if version >= 5 then
-      version = 5
+   if version >= 8 then
+      version = 8
    else
       defaults.gcc_rpath = false
    end


### PR DESCRIPTION
This changes the minimum OS X deployment target to 2 versions below the upcoming
current version, i.e. 10.10.

In a month or two, OS X 10.10 is coming out, but the current maximum
MACOSX_DEPLOYMENT_TARGET is 10.5, which was released in 2007, which was
7 years ago. Most users are on a higher version of OS X now. Plus, 10.6
introduced ARC, which doesn't compile when MACOSX_DEPLOYMENT_TARGET <=
10.6, and which is an insanely useful feature. Currently, trying to
enable ARC in a project involves having to override "CC", which in
general is a bad idea since it should be left to the user to
configure. Removing MACOSX_DEPLOYMENT_TARGET from the "CC" variable is
another story, but for now this commit should be sufficient to make
enabling ARC much easier.
