### PR TITLE
Fix luarocks lint

### DIFF
--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -216,7 +216,7 @@ local function type_check_item(version, item, typetbl, context)
       end
       if typetbl._pattern then
          if not item:match("^"..typetbl._pattern.."$") then
-            return nil, "Type mismatch on field "..context..": invalid value "..item.." does not match '"..expected.."'"
+            return nil, "Type mismatch on field "..context..": invalid value "..item.." does not match '"..typetbl._pattern.."'"
          end
       end
    elseif expected_type == "table" then


### PR DESCRIPTION
Now it does not crash on rockspecs with malformed version. 

Testcase: 

`$ echo 'version = "bad"' > testcase.rockspec`

Before: 

```
$ luarocks lint testcase.rockspec

Error: LuaRocks 2.2.0 bug (please report at luarocks-developers@lists.sourceforge.net).
/usr/local/share/lua/5.2/luarocks/type_check.lua:219: attempt to concatenate global 'expected' (a nil value)
stack traceback:
    /usr/local/share/lua/5.2/luarocks/type_check.lua:219: in function 'type_check_item'
    /usr/local/share/lua/5.2/luarocks/type_check.lua:276: in function </usr/local/share/lua/5.2/luarocks/type_check.lua:263>
    (...tail calls...)
    /usr/local/share/lua/5.2/luarocks/fetch.lua:198: in function 'load_local_rockspec'
    /usr/local/share/lua/5.2/luarocks/lint.lua:37: in function </usr/local/share/lua/5.2/luarocks/lint.lua:21>
    (...tail calls...)
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.2/luarocks/command_line.lua:208: in function 'run_command'
    /usr/local/bin/luarocks:33: in main chunk
    [C]: in ?
```

After: 

```
$ luarocks lint testcase.rockspec

Error: Failed loading rockspec: /home/mpeterv/test/testcase.rockspec: Type mismatch on field version: invalid value bad does not match '[%w.]+-[%d]+'
```
