### PR TITLE
fix "luarocks remove -> not found" with system root dir

### DIFF
--- a/src/luarocks/remove.lua
+++ b/src/luarocks/remove.lua
@@ -159,7 +159,7 @@ function remove.run(...)
    local results = {}
    search.manifest_search(results, cfg.rocks_dir, search.make_query(name, version))
    if not results[name] then
-      return nil, "Could not find rock '"..name..(version and " "..version or "").."' in "..cfg.root_dir
+      return nil, "Could not find rock '"..name..(version and " "..version or "").."' in "..path.rocks_dir(cfg.root_dir)
    end
 
    return remove.remove_search_results(results, name, deps_mode, flags["force"])


### PR DESCRIPTION
cfg.root_dir can be a table, so e.g. a typo in the name
of a rock to remove resulted in an error
