### PR TITLE
Removed some unused and global variables

### DIFF
--- a/src/luarocks/manif_core.lua
+++ b/src/luarocks/manif_core.lua
@@ -9,7 +9,6 @@ local persist = require("luarocks.persist")
 local type_check = require("luarocks.type_check")
 local dir = require("luarocks.dir")
 local util = require("luarocks.util")
-local cfg = require("luarocks.cfg")
 local path = require("luarocks.path")
 
 manif_core.manifest_cache = {}

--- a/src/luarocks/path_cmd.lua
+++ b/src/luarocks/path_cmd.lua
@@ -6,7 +6,6 @@ local path_cmd = {}
 local util = require("luarocks.util")
 local deps = require("luarocks.deps")
 local cfg = require("luarocks.cfg")
-local path = require("luarocks.path")
 
 path_cmd.help_summary = "Return the currently configured package path."
 path_cmd.help_arguments = ""

--- a/src/luarocks/persist.lua
+++ b/src/luarocks/persist.lua
@@ -54,8 +54,7 @@ function persist.load_into_table(filename, tbl)
    assert(type(filename) == "string")
    assert(type(tbl) == "table" or not tbl)
 
-   local result, ok, err
-   result = tbl or {}
+   local result = tbl or {}
    local globals = {}
    local globals_mt = {
       __index = function(t, n)
@@ -66,7 +65,7 @@ function persist.load_into_table(filename, tbl)
    local save_mt = getmetatable(result)
    setmetatable(result, globals_mt)
    
-   ok, err, errcode = run_file(filename, result)
+   local ok, err, errcode = run_file(filename, result)
    
    setmetatable(result, save_mt)
 

--- a/src/luarocks/upload/api.lua
+++ b/src/luarocks/upload/api.lua
@@ -155,7 +155,7 @@ function Api:request(url, params, post_params)
       if cfg.connection_timeout and cfg.connection_timeout > 0 then
         curl_cmd = curl_cmd .. "--connect-timeout "..tonumber(cfg.connection_timeout).." " 
       end
-      ok = fs.execute_string(curl_cmd..fs.Q(url).." -o "..fs.Q(tmpfile))
+      local ok = fs.execute_string(curl_cmd..fs.Q(url).." -o "..fs.Q(tmpfile))
       if not ok then
          return nil, "API failure: " .. tostring(url)
       end


### PR DESCRIPTION
Some tiny fixes. There are a lot more unused variables around but it's not obvious for me how to fix them. E.g. there are a lot of unused error messages (`local ok, err = ...`; `err` is then unused) which should probably be reported instead of simply being removed.
