### PR TITLE
Tiny persist.lua refactorings

### DIFF
--- a/src/luarocks/persist.lua
+++ b/src/luarocks/persist.lua
@@ -83,10 +83,10 @@ end
 
 local write_table
 
---- Write a value as Lua code, invoking write_table.
--- This function handles only numbers, strings and tables
--- are keys (tables are handled recursively).
--- @param out userdata: a file object, open for writing.
+--- Write a value as Lua code.
+-- This function handles only numbers and strings, invoking write_table
+-- to write tables.
+-- @param out table or userdata: a writer object supporting :write() method.
 -- @param v: the value to be written.
 -- @param level number: the indentation level
 -- @param sub_order table: optional prioritization table
@@ -95,28 +95,27 @@ local function write_value(out, v, level, sub_order)
    if type(v) == "table" then
       write_table(out, v, level + 1, sub_order)
    elseif type(v) == "string" then
-      if v:match("\n") then
+      if v:match("[\r\n]") then
          local open, close = "[[", "]]"
          local equals = 0
-         while v:find(open,1,true) or v:find(close,1,true) do
+         while v:find(close, 1, true) do
             equals = equals + 1
             local eqs = ("="):rep(equals)
             open, close = "["..eqs.."[", "]"..eqs.."]"
          end
          out:write(open.."\n"..v..close)
       else
-         out:write("\""..v:gsub("\"", "\\\"").."\"")
+         out:write("\""..v:gsub("\\", "\\\\"):gsub("\"", "\\\"").."\"")
       end
    else
       out:write(tostring(v))
    end
 end
 
---- Write a table as Lua code representing a table to disk
--- (that is, in curly brackets notation).
--- This function handles only numbers, strings and tables
--- are keys (tables are handled recursively).
--- @param out userdata: a file object, open for writing.
+--- Write a table as Lua code in curly brackets notation to a writer object.
+-- Only numbers, strings and tables (containing numbers, strings
+-- or other recursively processed tables) are supported.
+-- @param out table or userdata: a writer object supporting :write() method.
 -- @param tbl table: the table to be written.
 -- @param level number: the indentation level
 -- @param field_order table: optional prioritization table
@@ -131,28 +130,29 @@ write_table = function(out, tbl, level, field_order)
       if indent then
          for n = 1,level do out:write(indentation) end
       end
-      sep = ",\n"
-      indent = true
-      if type(k) == "number" then
-         if k ~= i then
-            out:write("["..tostring(k).."]=")
-         else
-            i = i + 1
-         end
-         indent = false
-         sep = ", "
-      elseif type(k) == "table" then
-         out:write("[")
-         write_table(out, k, level + 1)
-         out:write("] = ")
+
+      if k == i then
+         i = i + 1
       else
-         if k:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then
-            out:write(k.." = ")
+         if type(k) == "string" and k:match("^[a-zA-Z_][a-zA-Z0-9_]*$") then
+            out:write(k)
          else
-            out:write("['"..k:gsub("'", "\\'").."'] = ") 
+            out:write("[")
+            write_value(out, k, level)
+            out:write("]")
          end
+
+         out:write(" = ")
       end
+
       write_value(out, v, level, sub_order)
+      if type(k) == "number" then
+         sep = ", "
+         indent = false
+      else
+         sep = ",\n"
+         indent = true
+      end
    end
    if sep ~= "\n" then
       out:write("\n")
@@ -161,18 +161,16 @@ write_table = function(out, tbl, level, field_order)
    out:write("}")
 end
 
---- Writes a table to an io-like object.
--- @param out userdata: a file object, open for writing.
+--- Write a table as series of assignments to a writer object.
+-- @param out table or userdata: a writer object supporting :write() method.
 -- @param tbl table: the table to be written.
 -- @param field_order table: optional prioritization table
--- @return userdata The file object originally passed in as the `out` parameter.
-local function write_table(out, tbl, field_order)
+local function write_table_as_assignments(out, tbl, field_order)
    for k, v, sub_order in util.sortedpairs(tbl, field_order) do
       out:write(k.." = ")
       write_value(out, v, 0, sub_order)
       out:write("\n")
    end
-   return out
 end
 
 --- Save the contents of a table to a string.
@@ -185,7 +183,7 @@ end
 function persist.save_from_table_to_string(tbl, field_order)
    local out = {buffer = {}}
    function out:write(data) table.insert(self.buffer, data) end
-   write_table(out, tbl, field_order)
+   write_table_as_assignments(out, tbl, field_order)
    return table.concat(out.buffer)
 end
 
@@ -203,7 +201,7 @@ function persist.save_from_table(filename, tbl, field_order)
    if not out then
       return nil, "Cannot create file at "..filename
    end
-   write_table(out, tbl, field_order)
+   write_table_as_assignments(out, tbl, field_order)
    out:close()
    return true
 end


### PR DESCRIPTION
This fixes some small issues with `luarocks.persist` module:

* `persist.load_into_table` (used for loading rockspecs) used to read file twice on Lua 5.2/5.3;
* `persist.save_from_table` (used for saving manifests, etc.) used to produce broken code when table contained strings with backslashes or Windows-like newlines.