### PR TITLE
Revert incorrect remove of cmake_generator support.  ...

### DIFF
--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -37,6 +37,9 @@ function cmake.run(rockspec)
 
    -- Execute cmake with variables.
    local args = ""
+   if cfg.cmake_generator then
+      args = args .. ' -G"'..cfg.cmake_generator.. '"'
+   end
    for k,v in pairs(variables) do
       args = args .. ' -D' ..k.. '="' ..v.. '"'
    end

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -371,6 +371,7 @@ end
 if detected.mingw32 then
    defaults.platforms = { "win32", "mingw32", "windows" }
    defaults.obj_extension = "o"
+   defaults.cmake_generator = "MinGW Makefiles"
    defaults.variables.MAKE = "mingw32-make"
    defaults.variables.CC = "mingw32-gcc"
    defaults.variables.RC = "windres"
@@ -401,6 +402,7 @@ if detected.unix then
    defaults.variables.LUA_INCDIR = site_config.LUA_INCDIR or "/usr/local/include"
    defaults.variables.LUA_LIBDIR = site_config.LUA_LIBDIR or "/usr/local/lib"
    defaults.variables.CFLAGS = "-O2"
+   defaults.cmake_generator = "Unix Makefiles"
    defaults.platforms = { "unix" }
    defaults.variables.CC = "gcc"
    defaults.variables.LD = "gcc"
@@ -432,6 +434,7 @@ if detected.cygwin then
    defaults.lib_extension = "so" -- can be overridden in the config file for mingw builds
    defaults.arch = "cygwin-"..proc
    defaults.platforms = {"unix", "cygwin"}
+   defaults.cmake_generator = "Unix Makefiles"
    defaults.variables.CC = "echo -llua | xargs gcc"
    defaults.variables.LD = "echo -llua | xargs gcc"
    defaults.variables.LIBFLAG = "-shared"


### PR DESCRIPTION
Only windows msvc default cmake_generator are removed.
Windows mingw and cygwin cmake_generator default are kept.