### PR TITLE
Adds --only-deps flag to the 'build' command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: c
 
 compiler: gcc
 
+sudo: false
+
 env:
   matrix:
     - LUA_VER=5.1.5

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -378,7 +378,8 @@ local function do_build(name, version, deps_mode, build_only_deps)
       return build.build_rock(name, false, deps_mode, build_only_deps)
    elseif name:match("%.all%.rock$") then
       local install = require("luarocks.install")
-      return install.install_binary_rock(name, deps_mode)
+      local install_fun = build_only_deps and install.install_binary_rock_deps or install.install_binary_rock
+      return install_fun(name, deps_mode)
    elseif name:match("%.rock$") then
       return build.build_rock(name, true, deps_mode, build_only_deps)
    elseif not name:match(dir.separator) then

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -37,6 +37,8 @@ or the name of a rock to be fetched from a repository.
                     rockspec. Allows to specify a different branch to 
                     fetch. Particularly for SCM rocks.
 
+--only-deps         Installs only the dependencies of the rock.
+
 ]]..util.deps_mode_help()
 
 --- Install files to a given location.
@@ -157,9 +159,10 @@ end
 -- @param deps_mode string: Dependency mode: "one" for the current default tree,
 -- "all" for all trees, "order" for all trees with priority >= the current default,
 -- "none" for no trees.
+-- @param build_only_deps boolean: true to build the listed dependencies only.
 -- @return (string, string) or (nil, string, [string]): Name and version of
 -- installed rock if succeeded or nil and an error message followed by an error code.
-function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_mode)
+function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_mode, build_only_deps)
    assert(type(rockspec_file) == "string")
    assert(type(need_to_fetch) == "boolean")
 
@@ -181,13 +184,19 @@ function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_m
       end
    end
 
+   local name, version = rockspec.name, rockspec.version
+   if build_only_deps then
+      util.printout("Stopping after installing dependencies for " ..name.." "..version)
+      util.printout()
+      return name, version
+   end   
+
    local ok
    ok, err, errcode = deps.check_external_deps(rockspec, "build")
    if err then
       return nil, err, errcode
    end
 
-   local name, version = rockspec.name, rockspec.version
    if repos.is_installed(name, version) then
       repos.delete_version(name, version)
    end
@@ -341,9 +350,10 @@ end
 -- @param deps_mode: string: Which trees to check dependencies for:
 -- "one" for the current default tree, "all" for all trees,
 -- "order" for all trees with priority >= the current default, "none" for no trees.
+-- @param build_only_deps boolean: true to build the listed dependencies only.
 -- @return boolean or (nil, string, [string]): True if build was successful,
 -- or false and an error message and an optional error code.
-function build.build_rock(rock_file, need_to_fetch, deps_mode)
+function build.build_rock(rock_file, need_to_fetch, deps_mode, build_only_deps)
    assert(type(rock_file) == "string")
    assert(type(need_to_fetch) == "boolean")
 
@@ -356,24 +366,24 @@ function build.build_rock(rock_file, need_to_fetch, deps_mode)
    local rockspec_file = path.rockspec_name_from_rock(rock_file)
    ok, err = fs.change_dir(unpack_dir)
    if not ok then return nil, err end
-   ok, err, errcode = build.build_rockspec(rockspec_file, need_to_fetch, false, deps_mode)
+   ok, err, errcode = build.build_rockspec(rockspec_file, need_to_fetch, false, deps_mode, build_only_deps)
    fs.pop_dir()
    return ok, err, errcode
 end
  
-local function do_build(name, version, deps_mode)
+local function do_build(name, version, deps_mode, build_only_deps)
    if name:match("%.rockspec$") then
-      return build.build_rockspec(name, true, false, deps_mode)
+      return build.build_rockspec(name, true, false, deps_mode, build_only_deps)
    elseif name:match("%.src%.rock$") then
-      return build.build_rock(name, false, deps_mode)
+      return build.build_rock(name, false, deps_mode, build_only_deps)
    elseif name:match("%.all%.rock$") then
       local install = require("luarocks.install")
       return install.install_binary_rock(name, deps_mode)
    elseif name:match("%.rock$") then
-      return build.build_rock(name, true, deps_mode)
+      return build.build_rock(name, true, deps_mode, build_only_deps)
    elseif not name:match(dir.separator) then
       local search = require("luarocks.search")
-      return search.act_on_src_or_rockspec(build.run, name:lower(), version, deps.deps_mode_to_flag(deps_mode))
+      return search.act_on_src_or_rockspec(build.run, name:lower(), version, deps.deps_mode_to_flag(deps_mode), build_only_deps and "--only-deps")
    end
    return nil, "Don't know what to do with "..name
 end
@@ -398,9 +408,12 @@ function build.run(...)
    else
       local ok, err = fs.check_command_permissions(flags)
       if not ok then return nil, err, cfg.errorcodes.PERMISSIONDENIED end
-      ok, err = do_build(name, version, deps.get_deps_mode(flags))
+      ok, err = do_build(name, version, deps.get_deps_mode(flags), flags["only-deps"])
       if not ok then return nil, err end
       local name, version = ok, err
+      if flags["only-deps"] then
+         return name, version
+      end
       if (not flags["keep"]) and not cfg.keep_other_versions then
          local ok, err = remove.remove_other_versions(name, version, flags["force"])
          if not ok then util.printerr(err) end

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -26,6 +26,8 @@ or a filename of a locally available rock.
                     rock after installing a new one. This behavior can
                     be made permanent by setting keep_other_versions=true
                     in the configuration file.
+
+--only-deps         Installs only the dependencies of the rock.
 ]]..util.deps_mode_help()
 
 
@@ -109,6 +111,43 @@ function install.install_binary_rock(rock_file, deps_mode)
    return name, version
 end
 
+--- Installs the dependencies of a binary rock.
+-- @param rock_file string: local or remote filename of a rock.
+-- @param deps_mode: string: Which trees to check dependencies for:
+-- "one" for the current default tree, "all" for all trees,
+-- "order" for all trees with priority >= the current default, "none" for no trees.
+-- @return (string, string) or (nil, string, [string]): Name and version of
+-- the rock whose dependencies were installed if succeeded or nil and an error message 
+-- followed by an error code.
+function install.install_binary_rock_deps(rock_file, deps_mode)
+   assert(type(rock_file) == "string")
+
+   local name, version, arch = path.parse_name(rock_file)
+   if not name then
+      return nil, "Filename "..rock_file.." does not match format 'name-version-revision.arch.rock'."
+   end
+   
+   if arch ~= "all" and arch ~= cfg.arch then
+      return nil, "Incompatible architecture "..arch, "arch"
+   end
+
+   local ok, err, errcode = fetch.fetch_and_unpack_rock(rock_file, path.install_dir(name, version))
+   if not ok then return nil, err, errcode end
+   
+   local rockspec, err, errcode = fetch.load_rockspec(path.rockspec_file(name, version))
+   if err then
+      return nil, "Failed loading rockspec for installed package: "..err, errcode
+   end
+
+   ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode)
+   if err then return nil, err, errcode end
+
+   util.printout()
+   util.printout("Succesfully nstalling dependencies for " ..name.." "..version)
+
+   return name, version
+end
+
 --- Driver function for the "install" command.
 -- @param name string: name of a binary rock. If an URL or pathname
 -- to a binary rock is given, fetches and installs it. If a rockspec or a
@@ -131,12 +170,16 @@ function install.run(...)
    if name:match("%.rockspec$") or name:match("%.src%.rock$") then
       util.printout("Using "..name.."... switching to 'build' mode")
       local build = require("luarocks.build")
-      return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode"))
+      return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode", "only-deps"))
    elseif name:match("%.rock$") then
-      ok, err = install.install_binary_rock(name, deps.get_deps_mode(flags))
+      if flags["only-deps"] then
+         ok, err = install.install_binary_rock_deps(name, deps.get_deps_mode(flags))
+      else
+         ok, err = install.install_binary_rock(name, deps.get_deps_mode(flags))
+      end
       if not ok then return nil, err end
       local name, version = ok, err
-      if (not flags["keep"]) and not cfg.keep_other_versions then
+      if (not flags["only-deps"]) and (not flags["keep"]) and not cfg.keep_other_versions then
          local ok, err = remove.remove_other_versions(name, version, flags["force"])
          if not ok then util.printerr(err) end
       end

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -143,7 +143,7 @@ function install.install_binary_rock_deps(rock_file, deps_mode)
    if err then return nil, err, errcode end
 
    util.printout()
-   util.printout("Succesfully nstalling dependencies for " ..name.." "..version)
+   util.printout("Succesfully installed dependencies for " ..name.." "..version)
 
    return name, version
 end

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -102,6 +102,7 @@ local supported_flags = {
    ["no-refresh"] = true,
    ["nodeps"] = true,
    ["old-versions"] = true,
+   ["only-deps"] = true,
    ["only-from"] = "<server>",
    ["only-server"] = "<server>",
    ["only-sources"] = "<url>",

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -143,15 +143,15 @@ local tests = {
    test_build_only_deps_rockspec = function()
       return run "$luarocks download --rockspec lxsh ${verrev_lxsh}"
          and run "$luarocks build ./lxsh-${verrev_lxsh}.rockspec --only-deps"
-         and run "$luarocks show lxsh; [ $? -ne 0 ]; };"
+         and (not run "$luarocks show lxsh")
    end,
    test_build_only_deps_src_rock = function()
       return run "$luarocks download --source lxsh ${verrev_lxsh}"
          and run "$luarocks build ./lxsh-${verrev_lxsh}.src.rock --only-deps"
-         and run "$luarocks show lxsh; [ $? -ne 0 ]; };"
+         and (not run "$luarocks show lxsh")
    end,
-   test_build_only_deps = function() return run "$luarocks build luasec --only-deps" and run "$luarocks show luasec; [ $? -ne 0 ]; };" end,
-   test_install_only_deps = function() return run "$luarocks install lxsh ${verrev_lxsh} --only-deps" and run "$luarocks show lxsh; [ $? -ne 0 ]; };" end,
+   test_build_only_deps = function() return run "$luarocks build luasec --only-deps" and (not run "$luarocks show luasec") end,
+   test_install_only_deps = function() return run "$luarocks install lxsh ${verrev_lxsh} --only-deps" and (not run "$luarocks show lxsh") end,
    fail_build_missing_external = function() return run '$luarocks build "$testing_dir/testfiles/missing_external-0.1-1.rockspec" INEXISTENT_INCDIR="/invalid/dir"' end,
    fail_build_invalidpatch = function()
       need_luasocket()

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -140,6 +140,18 @@ local tests = {
          and rm "./validate-args-${verrev_validate_args}.rockspec"
    end,
    test_build_supported_platforms = function() return run "$luarocks build lpty" end,
+   test_build_only_deps_rockspec = function()
+      return run "$luarocks download --rockspec lxsh ${verrev_lxsh}"
+         and run "$luarocks build ./lxsh-${verrev_lxsh}.rockspec --only-deps"
+         and run "$luarocks show lxsh; [ $? -ne 0 ]; };"
+   end,
+   test_build_only_deps_src_rock = function()
+      return run "$luarocks download --source lxsh ${verrev_lxsh}"
+         and run "$luarocks build ./lxsh-${verrev_lxsh}.src.rock --only-deps"
+         and run "$luarocks show lxsh; [ $? -ne 0 ]; };"
+   end,
+   test_build_only_deps = function() return run "$luarocks build luasec --only-deps" and run "$luarocks show luasec; [ $? -ne 0 ]; };" end,
+   test_install_only_deps = function() return run "$luarocks install lxsh ${verrev_lxsh} --only-deps" and run "$luarocks show lxsh; [ $? -ne 0 ]; };" end,
    fail_build_missing_external = function() return run '$luarocks build "$testing_dir/testfiles/missing_external-0.1-1.rockspec" INEXISTENT_INCDIR="/invalid/dir"' end,
    fail_build_invalidpatch = function()
       need_luasocket()

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -263,7 +263,6 @@ mkdir -p "$testing_server"
    get "$luarocks_repo/lua-path-0.2.3-1.src.rock"
    get "$luarocks_repo/lua-cjson-2.1.0-1.src.rock"
    get "$luarocks_repo/luacov-coveralls-0.1.1-1.src.rock"
-   get "$luarocks_repo/luacov-coveralls-0.1.1-1.src.rock"
 )
 $luarocks_admin_nocov make_manifest "$testing_server"
 

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -387,24 +387,10 @@ test_build_install_bin() { $luarocks build luarepl; }
 test_build_nohttps() { need_luasocket; $luarocks download --rockspec validate-args ${verrev_validate_args} && $luarocks build ./validate-args-${version_validate_args}-1.rockspec && rm ./validate-args-${version_validate_args}-1.rockspec; }
 test_build_https() { need_luasocket; $luarocks download --rockspec validate-args ${verrev_validate_args} && $luarocks install $luasec && $luarocks build ./validate-args-${verrev_validate_args}.rockspec && rm ./validate-args-${verrev_validate_args}.rockspec; }
 test_build_supported_platforms() { $luarocks build lpty; }
-test_build_only_deps_rockspec() { $luarocks download --rockspec lxsh ${verrev_lxsh} ; $luarocks build ./lxsh-${verrev_lxsh}.rockspec --only-deps; $luarocks show lxsh;
-   if [ $? -ne 0 ]
-   then return 0;
-   fi;
-   return 1;
-}
-test_build_only_deps_src_rock() { $luarocks download --source lxsh ${verrev_lxsh} ; $luarocks build ./lxsh-${verrev_lxsh}.src.rock --only-deps; $luarocks show lxsh;
-   if [ $? -ne 0 ]
-   then return 0;
-   fi;
-   return 1;
-}
-test_build_only_deps() { $luarocks build luasec --only-deps; $luarocks show luasec;
-   if [ $? -ne 0 ]
-   then return 0;
-   fi;
-   return 1;
-}
+test_build_only_deps_rockspec() { $luarocks download --rockspec lxsh ${verrev_lxsh} && $luarocks build ./lxsh-${verrev_lxsh}.rockspec --only-deps && { $luarocks show lxsh; [ $? -ne 0 ]; }; }
+test_build_only_deps_src_rock() { $luarocks download --source lxsh ${verrev_lxsh} && $luarocks build ./lxsh-${verrev_lxsh}.src.rock --only-deps && { $luarocks show lxsh; [ $? -ne 0 ]; }; }
+test_build_only_deps() { $luarocks build luasec --only-deps && { $luarocks show luasec; [ $? -ne 0 ]; }; }
+test_install_only_deps() { $luarocks install lxsh ${verrev_lxsh} --only-deps && { $luarocks show lxsh; [ $? -ne 0 ]; }; }
 fail_build_missing_external() { $luarocks build "$testing_dir/testfiles/missing_external-0.1-1.rockspec" INEXISTENT_INCDIR="/invalid/dir"; }
 fail_build_invalidpatch() { need_luasocket; $luarocks build "$testing_dir/testfiles/invalid_patch-0.1-1.rockspec"; }
 

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -249,6 +249,7 @@ mkdir -p "$testing_server"
    get "$luarocks_repo/cprint-${verrev_cprint}.rockspec"
    get "$luarocks_repo/wsapi-1.6-1.src.rock"
    get "$luarocks_repo/lxsh-${verrev_lxsh}.src.rock"
+   get "$luarocks_repo/lxsh-${verrev_lxsh}.rockspec"
    get "$luarocks_repo/abelhas-${verrev_abelhas}.rockspec"
    get "$luarocks_repo/lzlib-0.4.1.53-1.src.rock"
    get "$luarocks_repo/lpeg-0.12-1.src.rock"
@@ -261,6 +262,7 @@ mkdir -p "$testing_server"
    get "$luarocks_repo/lmathx-20140620-1.rockspec"
    get "$luarocks_repo/lua-path-0.2.3-1.src.rock"
    get "$luarocks_repo/lua-cjson-2.1.0-1.src.rock"
+   get "$luarocks_repo/luacov-coveralls-0.1.1-1.src.rock"
    get "$luarocks_repo/luacov-coveralls-0.1.1-1.src.rock"
 )
 $luarocks_admin_nocov make_manifest "$testing_server"
@@ -385,6 +387,24 @@ test_build_install_bin() { $luarocks build luarepl; }
 test_build_nohttps() { need_luasocket; $luarocks download --rockspec validate-args ${verrev_validate_args} && $luarocks build ./validate-args-${version_validate_args}-1.rockspec && rm ./validate-args-${version_validate_args}-1.rockspec; }
 test_build_https() { need_luasocket; $luarocks download --rockspec validate-args ${verrev_validate_args} && $luarocks install $luasec && $luarocks build ./validate-args-${verrev_validate_args}.rockspec && rm ./validate-args-${verrev_validate_args}.rockspec; }
 test_build_supported_platforms() { $luarocks build lpty; }
+test_build_only_deps_rockspec() { $luarocks download --rockspec lxsh ${verrev_lxsh} ; $luarocks build ./lxsh-${verrev_lxsh}.rockspec --only-deps; $luarocks show lxsh;
+   if [ $? -ne 0 ]
+   then return 0;
+   fi;
+   return 1;
+}
+test_build_only_deps_src_rock() { $luarocks download --source lxsh ${verrev_lxsh} ; $luarocks build ./lxsh-${verrev_lxsh}.src.rock --only-deps; $luarocks show lxsh;
+   if [ $? -ne 0 ]
+   then return 0;
+   fi;
+   return 1;
+}
+test_build_only_deps() { $luarocks build luasec --only-deps; $luarocks show luasec;
+   if [ $? -ne 0 ]
+   then return 0;
+   fi;
+   return 1;
+}
 fail_build_missing_external() { $luarocks build "$testing_dir/testfiles/missing_external-0.1-1.rockspec" INEXISTENT_INCDIR="/invalid/dir"; }
 fail_build_invalidpatch() { need_luasocket; $luarocks build "$testing_dir/testfiles/invalid_patch-0.1-1.rockspec"; }
 


### PR DESCRIPTION
As discussed in #287, adds a new flag (--only-deps) to the 'build' command, so only the dependencies of a rock are installed, and not the rock itself.

Feedback is welcome. Specially, I don't know if I should add this [also here](https://github.com/keplerproject/luarocks/blob/master/src/luarocks/build.lua#L371). I think it is best not to add it there, since 'install' removes the installed rock and we don't want that.