### PR TITLE
Print a warning and stop if the old url is present.

### DIFF
--- a/src/luarocks/upload/api.lua
+++ b/src/luarocks/upload/api.lua
@@ -21,6 +21,7 @@ function Api:load_config()
    local upload_conf = upload_config_file()
    if not upload_conf then return nil end
    local cfg, err = persist.load_into_table(upload_conf)
+   if not cfg then return cfg, err end
    -- Warn on old repository url
    if cfg.server:match("^http[s?]://rocks.moonscript.org") then
       util.printerr("Warning: The main rocks repository is now located at https://luarocks.org")

--- a/src/luarocks/upload/api.lua
+++ b/src/luarocks/upload/api.lua
@@ -21,6 +21,12 @@ function Api:load_config()
    local upload_conf = upload_config_file()
    if not upload_conf then return nil end
    local cfg, err = persist.load_into_table(upload_conf)
+   -- Warn on old repository url
+   if cfg.server:match("^http[s?]://rocks.moonscript.org") then
+      util.printerr("Warning: The main rocks repository is now located at https://luarocks.org")
+      util.printerr("Edit your upload configuration at '" .. upload_config_file()  .."'")
+      return nil, "Your upload client is too out of date to continue, please upgrade LuaRocks."
+   end
    return cfg
 end
 


### PR DESCRIPTION
When trying to upload, and your _upload_config.lua_ file still has the old url, print a warning and exit (not so cleanly, it wrongly reports that you're missing the api key, which, probably, you're not).

~~~
$ luarocks upload rockspecs/nozzle-git-1.rockspec

Warning: The main rocks repository is now located at https://luarocks.org
Edit your upload configuration at 'C:/Users/Ignacio/AppData/Roaming/luarocks/upload_config.lua'

Error: You need an API key to upload rocks.
Navigate to https://luarocks.org/settings to get a key
and then pass it through the --api-key=<key> flag.
~~~