### PR TITLE
Support for configuring proxy via environment variable

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -597,6 +597,12 @@ cfg.user_agent = "LuaRocks/"..cfg.program_version.." "..cfg.arch
 
 cfg.http_proxy = os.getenv("http_proxy")
 cfg.https_proxy = os.getenv("https_proxy")
+cfg.no_proxy = os.getenv("no_proxy")
+
+-- make sure that no_proxy is not 'alone'
+if cfg.no_proxy and not (cfg.https_proxy or cfg.http_proxy) then
+   cfg.no_proxy = nil
+end
 
 --- Check if platform was detected
 -- @param query string: The platform name to check.

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -595,6 +595,9 @@ end
 
 cfg.user_agent = "LuaRocks/"..cfg.program_version.." "..cfg.arch
 
+cfg.http_proxy = os.getenv("http_proxy")
+cfg.https_proxy = os.getenv("https_proxy")
+
 --- Check if platform was detected
 -- @param query string: The platform name to check.
 -- @return boolean: true if LuaRocks is currently running on queried platform.

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -599,11 +599,6 @@ cfg.http_proxy = os.getenv("http_proxy")
 cfg.https_proxy = os.getenv("https_proxy")
 cfg.no_proxy = os.getenv("no_proxy")
 
--- make sure that no_proxy is not 'alone'
-if cfg.no_proxy and not (cfg.https_proxy or cfg.http_proxy) then
-   cfg.no_proxy = nil
-end
-
 --- Check if platform was detected
 -- @param query string: The platform name to check.
 -- @return boolean: true if LuaRocks is currently running on queried platform.

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -653,6 +653,11 @@ function fs_lua.download(url, filename, cache)
    assert(type(filename) == "string" or not filename)
 
    filename = fs.absolute_name(filename or dir.base_name(url))
+
+   -- delegate to the configured downloader so we don't have to deal with whitelists
+   if cfg.no_proxy then
+      return fs.use_downloader(url, filename, cache)
+   end
    
    local content, err, https_err
    if util.starts_with(url, "http:") then
@@ -660,6 +665,7 @@ function fs_lua.download(url, filename, cache)
    elseif util.starts_with(url, "ftp:") then
       content, err = ftp.get(url)
    elseif util.starts_with(url, "https:") then
+      -- skip LuaSec when proxy is enabled since it is not supported
       if luasec_ok and not cfg.https_proxy then
          content, err = http_request(url, https, cache and filename)
       else

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -545,7 +545,7 @@ local redirect_protocols = {
 local function request(url, method, http, loop_control)
    local result = {}
    
-   local proxy = cfg.proxy
+   local proxy = cfg.http_proxy
    if type(proxy) ~= "string" then proxy = nil end
    -- LuaSocket's http.request crashes when given URLs missing the scheme part.
    if proxy and not proxy:find("://") then
@@ -660,7 +660,7 @@ function fs_lua.download(url, filename, cache)
    elseif util.starts_with(url, "ftp:") then
       content, err = ftp.get(url)
    elseif util.starts_with(url, "https:") then
-      if luasec_ok then
+      if luasec_ok and not cfg.https_proxy then
          content, err = http_request(url, https, cache and filename)
       else
          https_err = true


### PR DESCRIPTION
Implements what's have been proposed in #337

Basically, we now honor the following environment variables:
- http_proxy
- https_proxy
- no_proxy