### PR TITLE
Add config_cmd.lua to Makefile.setup.inc.

### DIFF
--- a/Makefile.setup.inc
+++ b/Makefile.setup.inc
@@ -7,11 +7,11 @@ LUADIR ?= $(PREFIX)/share/lua/$(LUA_VERSION)/
 BIN_FILES = luarocks luarocks-admin
 LUAROCKS_FILES = fs/unix/tools.lua fs/unix.lua fs/win32/tools.lua fs/win32.lua \
 fs/lua.lua persist.lua list.lua require.lua repos.lua dir.lua make_manifest.lua \
-command_line.lua install.lua build/command.lua build/cmake.lua build/make.lua \
-build/builtin.lua fetch/cvs.lua fetch/git.lua fetch/sscm.lua tools/patch.lua \
-fetch/svn.lua tools/zip.lua tools/tar.lua pack.lua type_check.lua make.lua \
-remove.lua fs.lua manif.lua add.lua deps.lua build.lua search.lua show.lua \
-manif_core.lua fetch.lua unpack.lua validate.lua cfg.lua download.lua \
+command_line.lua config_cmd.lua install.lua build/command.lua build/cmake.lua \
+build/make.lua build/builtin.lua fetch/cvs.lua fetch/git.lua fetch/sscm.lua \
+tools/patch.lua fetch/svn.lua tools/zip.lua tools/tar.lua pack.lua type_check.lua \
+make.lua remove.lua fs.lua manif.lua add.lua deps.lua build.lua search.lua \
+show.lua manif_core.lua fetch.lua unpack.lua validate.lua cfg.lua download.lua \
 help.lua util.lua index.lua cache.lua refresh_cache.lua loader.lua \
 admin_remove.lua fetch/hg.lua fetch/git_file.lua new_version.lua lint.lua \
 purge.lua path.lua path_cmd.lua write_rockspec.lua doc.lua upload.lua \


### PR DESCRIPTION
Without config_cmd.lua in the list of LuaRocks files to install
the installation is broken and throws an error when trying to
display the usage message.