### PR TITLE
cmake backend: Generate 64 bits build when appropiate

### DIFF
--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -37,16 +37,16 @@ function cmake.run(rockspec)
 
    -- Execute cmake with variables.
    local args = ""
-   if cfg.cmake_generator then
+   
+   -- Try to pick the best generator. With msvc and x64, CMake does not select it by default so we need to be explicit.
+   if cfg.is_platform("mingw32") and cfg.cmake_generator then
       args = args .. ' -G"'..cfg.cmake_generator.. '"'
-   end
-   for k,v in pairs(variables) do
-      args = args .. ' -D' ..k.. '="' ..v.. '"'
+   elseif cfg.is_platform("windows") and cfg.arch:match("%-x86_64$") then
+      args = args .. " -DCMAKE_GENERATOR_PLATFORM=x64"
    end
 
-   -- Generate 64 bit build if appropiate.
-   if not not cfg.arch:match("%-x86_64$") then
-      args = args .. " -DCMAKE_GENERATOR_PLATFORM=x64"
+   for k,v in pairs(variables) do
+      args = args .. ' -D' ..k.. '="' ..tostring(v).. '"'
    end
 
    if not fs.execute_string(rockspec.variables.CMAKE.." -H. -Bbuild.luarocks "..args) then

--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -41,7 +41,7 @@ function cmake.run(rockspec)
    -- Try to pick the best generator. With msvc and x64, CMake does not select it by default so we need to be explicit.
    if cfg.is_platform("mingw32") and cfg.cmake_generator then
       args = args .. ' -G"'..cfg.cmake_generator.. '"'
-   elseif cfg.is_platform("windows") and cfg.arch:match("%-x86_64$") then
+   elseif cfg.is_platform("windows") and cfg.target_cpu:match("x86_64$") then
       args = args .. " -DCMAKE_GENERATOR_PLATFORM=x64"
    end
 

--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -35,7 +35,6 @@ function cmake.run(rockspec)
       cmake_handler:close()
    end
 
-
    -- Execute cmake with variables.
    local args = ""
    if cfg.cmake_generator then
@@ -43,6 +42,11 @@ function cmake.run(rockspec)
    end
    for k,v in pairs(variables) do
       args = args .. ' -D' ..k.. '="' ..v.. '"'
+   end
+
+   -- Generate 64 bit build if appropiate.
+   if not not cfg.arch:match("%-x86_64$") then
+      args = args .. " -DCMAKE_GENERATOR_PLATFORM=x64"
    end
 
    if not fs.execute_string(rockspec.variables.CMAKE.." -H. -Bbuild.luarocks "..args) then

--- a/src/luarocks/build/cmake.lua
+++ b/src/luarocks/build/cmake.lua
@@ -39,7 +39,7 @@ function cmake.run(rockspec)
    local args = ""
    
    -- Try to pick the best generator. With msvc and x64, CMake does not select it by default so we need to be explicit.
-   if cfg.is_platform("mingw32") and cfg.cmake_generator then
+   if cfg.cmake_generator then
       args = args .. ' -G"'..cfg.cmake_generator.. '"'
    elseif cfg.is_platform("windows") and cfg.target_cpu:match("x86_64$") then
       args = args .. " -DCMAKE_GENERATOR_PLATFORM=x64"


### PR DESCRIPTION
Adds -DCMAKE_GENERATOR_PLATFORM=x64 when needed. It seems that CMake does not do that by default (although I might be wrong on that).

fixes #382