### PR TITLE
Add version-specific overrides, similar to platform-specific overrides

### DIFF
--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -212,6 +212,12 @@ function fetch.load_local_rockspec(filename, quick)
    util.platform_overrides(rockspec.source)
    util.platform_overrides(rockspec.hooks)
 
+   util.version_overrides(rockspec.build)
+   util.version_overrides(rockspec.dependencies)
+   util.version_overrides(rockspec.external_dependencies)
+   util.version_overrides(rockspec.source)
+   util.version_overrides(rockspec.hooks)
+
    local basename = dir.base_name(filename)
    if basename == "rockspec" then
       rockspec.name = rockspec.package:lower()

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -280,6 +280,31 @@ function util.platform_overrides(tbl)
    tbl.platforms = nil
 end
 
+--- Perform version-specific overrides on a table.
+-- This works exactly like platform-specific overrides, with the
+-- exception that the keys of the "versions" table are matched against
+-- the cfg.lua_version field.  If a match is found, all fields in the
+-- matched table overwrite those of tbl, as for platform-specific
+-- overrides.
+-- @param tbl table or nil: Table which may contain a "versions" field;
+-- if it doesn't (or if nil is passed), this function does nothing.
+function util.version_overrides(tbl)
+   assert(type(tbl) == "table" or not tbl)
+
+   local cfg = require("luarocks.cfg")
+
+   if not tbl then return end
+
+   if tbl.versions then
+      local version = cfg.lua_version
+      local version_tbl = tbl.versions[version]
+      if version_tbl then
+         util.deep_merge(tbl, version_tbl)
+      end
+   end
+   tbl.versions = nil
+end
+
 local var_format_pattern = "%$%((%a[%a%d_]+)%)"
 
 --- Create a new shallow copy of a table: a new table with


### PR DESCRIPTION
This pull request adds version-specific overrides, which work and are implemented in a way almost identical to platform-specific overrides.  This feature would allow one to tailor the build process according to the Lua version.

My use case for this is, that I'd like to be able to append the Lua version to an executable script that's installed alongside a module, so that multiple versions of the script, for multiple vesions of Lua can be installed side-by-side in the same bin directory.  I imagine other uses will exist.

Note that as the overrides are applied after platform overrides one should be able to combine these, putting version overrides within platform overrides. 