### PR TITLE
Read os variables from config files

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -145,28 +145,7 @@ end
 cfg.variables = {}
 cfg.rocks_trees = {}
 
--- some extras for the global environment in the config files;
-cfg.os_getenv = os.getenv
-cfg.__dump_env = function()
-  -- debug function, calling it from a config file will show all 
-  -- available globals to that config file
-  print(util.show_table(cfg, "global environment"))
-end
-
-sys_config_file = site_config.LUAROCKS_SYSCONFIG or sys_config_dir.."/config-"..cfg.lua_version..".lua"
-do
-   local err, errcode
-   sys_config_ok, err, errcode = persist.load_into_table(sys_config_file, cfg)
-   if (not sys_config_ok) and errcode == "open" then -- file not found, so try alternate file
-      sys_config_file = sys_config_dir.."/config.lua"
-      sys_config_ok, err, errcode = persist.load_into_table(sys_config_file, cfg)
-   end
-   if (not sys_config_ok) and errcode ~= "open" then -- either "load" or "run"; bad config file, bail out with error
-      io.stderr:write(err.."\n")
-      os.exit(cfg.errorcodes.CONFIGFILE)
-   end
-end
-
+-- The global environment in the config files;
 local env_for_config_file
 env_for_config_file = {
    home = cfg.home,
@@ -174,12 +153,26 @@ env_for_config_file = {
    platform = util.make_shallow_copy(detected),
    processor = proc,
    os_getenv = os.getenv, 
-   __dump_env = function()
+   dump_env = function()
      -- debug function, calling it from a config file will show all 
      -- available globals to that config file
      print(util.show_table(env_for_config_file, "global environment"))
    end,
 }
+
+sys_config_file = site_config.LUAROCKS_SYSCONFIG or sys_config_dir.."/config-"..cfg.lua_version..".lua"
+do
+   local err, errcode
+   sys_config_ok, err, errcode = persist.load_into_table(sys_config_file, env_for_config_file)
+   if (not sys_config_ok) and errcode == "open" then -- file not found, so try alternate file
+      sys_config_file = sys_config_dir.."/config.lua"
+      sys_config_ok, err, errcode = persist.load_into_table(sys_config_file, env_for_config_file)
+   end
+   if (not sys_config_ok) and errcode ~= "open" then -- either "load" or "run"; bad config file, bail out with error
+      io.stderr:write(err.."\n")
+      os.exit(cfg.errorcodes.CONFIGFILE)
+   end
+end
 
 if not site_config.LUAROCKS_FORCE_CONFIG then
 

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -145,7 +145,7 @@ end
 cfg.variables = {}
 cfg.rocks_trees = {}
 
--- some extras for the global enviornment in the config files;
+-- some extras for the global environment in the config files;
 cfg.os_getenv = os.getenv
 cfg.__dump_env = function()
   -- debug function, calling it from a config file will show all 

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -145,6 +145,14 @@ end
 cfg.variables = {}
 cfg.rocks_trees = {}
 
+-- some extras for the global enviornment in the config files;
+cfg.os_getenv = os.getenv
+cfg.__dump_env = function()
+  -- debug function, calling it from a config file will show all 
+  -- available globals to that config file
+  print(util.show_table(cfg, "global environment"))
+end
+
 sys_config_file = site_config.LUAROCKS_SYSCONFIG or sys_config_dir.."/config-"..cfg.lua_version..".lua"
 do
    local err, errcode
@@ -159,11 +167,18 @@ do
    end
 end
 
-local env_for_config_file = {
+local env_for_config_file
+env_for_config_file = {
    home = cfg.home,
    lua_version = cfg.lua_version,
    platform = util.make_shallow_copy(detected),
    processor = proc,
+   os_getenv = os.getenv, 
+   __dump_env = function()
+     -- debug function, calling it from a config file will show all 
+     -- available globals to that config file
+     print(util.show_table(env_for_config_file, "global environment"))
+   end,
 }
 
 if not site_config.LUAROCKS_FORCE_CONFIG then


### PR DESCRIPTION
added 2 functions to the global environment of the config-file loader sandbox; `os_getenv()` and `__dump_env()`

The first is the same as the `os.getenv()` standard function. I didn't create a sub table as it is passed by reference and would allow one to override it, which might then possibly be reused for loading another config file.

The latter is for setup/debug purposes and will dump the environment passed to the config file. So adding `__dump_env()` line to `config.lua` and then execute `luarocks` to try it. It will dump all available input for the config file.

example results;
````
Microsoft Windows [versie 6.1.7601]
Copyright (c) 2009 Microsoft Corporation. Alle rechten voorbehouden.

C:\Users\Thijs>luarocks
global environment = {
   ["program_series"] = "2.2";
   ["lua_version"] = "5.1";
   ["errorcodes"] = {
      ["OK"] = 0;
      ["CONFIGFILE"] = 3;
      ["CRASH"] = 99;
      ["PERMISSIONDENIED"] = 2;
      ["UNSPECIFIED"] = 1;
   };
   ["verbose"] = "false";
   ["__dump_env"] = "function: 004821F8, defined in (150-154)@C:\\Program Files (x86)\\LuaRocks\\2.2\\lua\\luarocks\\cfg
.lua";
   ["site_config"] = {
      ["LUA_INCDIR"] = "C:\\Program Files (x86)\\Lua\\5.1\\include\\";
      ["LUAROCKS_UNAME_M"] = "x86";
      ["LUAROCKS_SYSCONFIG"] = "C:\\Program Files (x86)\\LuaRocks\\config.lua";
      ["LUAROCKS_ROCKS_TREE"] = "C:\\Program Files (x86)\\LuaRocks\\systree";
      ["LUAROCKS_MD5CHECKER"] = "md5sum";
      ["LUAROCKS_DOWNLOADER"] = "wget";
      ["LUA_INTERPRETER"] = "lua.exe";
      ["LUA_LIBDIR"] = "C:\\Program Files (x86)\\Lua\\5.1\\bin\\";
      ["LUAROCKS_PREFIX"] = "C:\\Program Files (x86)\\LuaRocks";
      ["LUAROCKS_UNAME_S"] = "MINGW";
      ["LUA_BINDIR"] = "C:\\Program Files (x86)\\Lua\\5.1\\bin\\";
   };
   ["program_version"] = "scm";
   ["home"] = "C:\\Users\\Thijs\\AppData\\Roaming";
   ["rocks_trees"] = {
      [1] = {
         ["name"] = "user";
         ["root"] = "C:\\Users\\Thijs\\AppData\\Roaming/luarocks";
      };
      [2] = {
         ["name"] = "system";
         ["root"] = "C:\\Program Files (x86)\\LuaRocks\\systree";
      };
   };
   ["variables"] = {
      ["LUALIB"] = "lua51.dll";
      ["MSVCRT"] = "m";
   };
   ["os_getenv"] = "function: 008E99B0, C function";
   ["major_version"] = "2.2";
   ["home_tree"] = "C:\\Users\\Thijs\\AppData\\Roaming/luarocks/";
};


LuaRocks scm, a module deployment system for Lua

NAME
        C:\Program Files (x86)\LuaRocks\2.2\luarocks.lua - LuaRocks main command-line interface

<snip>
````