### PR TITLE
Checks if git is installed

### DIFF
--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -40,6 +40,10 @@ function git.get_sources(rockspec, extract, dest_dir, depth)
    -- Strip off .git from base name if present
    module = module:gsub("%.git$", "")
 
+   if not fs.execute_quiet(git_cmd, "--version") then
+      return nil, "'"..git_cmd.."' program not found. Is git installed? You may want to edit variables.GIT"
+   end
+
    local store_dir
    if not dest_dir then
       store_dir = fs.make_temp_dir(name_version)


### PR DESCRIPTION
When sources are to be fetched using git, check beforehand it is available in the path instead of causing an error.

It will show the message:
`Error: 'git' program not found. Is git installed? You may want to edit variables.GIT`

and exit.

refs #381