### PR TITLE
Make 'build' field in rockspecs mandatory.

### DIFF
--- a/src/luarocks/type_check.lua
+++ b/src/luarocks/type_check.lua
@@ -87,7 +87,8 @@ local rockspec_types = {
       copy_directories = {
          _any = string_1,
       },
-      _more = true
+      _more = true,
+      _mandatory = true
    },
    hooks = {
       platforms = {}, -- recursively defined below

--- a/test/testfiles/no_build_table-0.1-1.rockspec
+++ b/test/testfiles/no_build_table-0.1-1.rockspec
@@ -1,0 +1,12 @@
+package = "no_build_table"
+version = "0.1-1"
+source = {
+   -- any valid URL
+   url = "https://raw.github.com/keplerproject/luarocks/master/src/luarocks/build.lua"
+}
+description = {
+   summary = "A rockspec with no build field",
+}
+dependencies = {
+   "lua >= 5.1"
+}

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -203,6 +203,7 @@ local tests = {
    fail_lint_type_mismatch_string = function() return run '$luarocks lint "$testing_dir/testfiles/type_mismatch_string-1.0-1.rockspec"' end,
    fail_lint_type_mismatch_version = function() return run '$luarocks lint "$testing_dir/testfiles/type_mismatch_version-1.0-1.rockspec"' end,
    fail_lint_type_mismatch_table = function() return run '$luarocks lint "$testing_dir/testfiles/type_mismatch_table-1.0-1.rockspec"' end,
+   fail_lint_no_build_table = function() return run '$luarocks lint "$testing_dir/testfiles/no_build_table-0.1-1.rockspec"' end,
    test_list = function() return run "$luarocks list" end,
    test_list_porcelain = function() return run "$luarocks list --porcelain" end,
    test_make_with_rockspec = function()

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -419,6 +419,7 @@ test_lint_ok() { $luarocks download --rockspec validate-args ${verrev_validate_a
 fail_lint_type_mismatch_string() { $luarocks lint "$testing_dir/testfiles/type_mismatch_string-1.0-1.rockspec"; }
 fail_lint_type_mismatch_version() { $luarocks lint "$testing_dir/testfiles/type_mismatch_version-1.0-1.rockspec"; }
 fail_lint_type_mismatch_table() { $luarocks lint "$testing_dir/testfiles/type_mismatch_table-1.0-1.rockspec"; }
+fail_lint_no_build_table() { $luarocks lint "$testing_dir/testfiles/no_build_table-0.1-1.rockspec"; }
 
 test_list() { $luarocks list; }
 test_list_porcelain() { $luarocks list --porcelain; }


### PR DESCRIPTION
Rockspecs must have a 'build' field. If by any chance, it is not needed (see #379), add this to the rockspec.

````lua
build = { type = "none" }
````