### PR TITLE
luarocks list does not respect the --local flag

### DIFF
--- a/src/luarocks/command_line.lua
+++ b/src/luarocks/command_line.lua
@@ -155,6 +155,7 @@ function command_line.run_command(...)
              "You are running as a superuser, which is intended for system-wide operation.\n"..
              "To force using the superuser's home, use --tree explicitly.")
       end
+      args[#args + 1] = "--tree="..cfg.home_tree
       replace_tree(flags, args, cfg.home_tree)
    else
       local trees = cfg.rocks_trees


### PR DESCRIPTION
~~~~
d:\Desarrollo\luarocks>luarocks list oauth --local

Installed rocks:
----------------

oauth
   0.0.6-1 (installed) - c:/luarocks/systree/lib/luarocks/rocks
~~~~

I couldn't find where the --local flag is dealt with. It is mapped to --tree=/path/to/home/tree somewhere?