### PR TITLE
write_rockspec: allow selecting rockspec format

### DIFF
--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -118,6 +118,7 @@ local supported_flags = {
    ["rock-tree"] = true,
    ["rock-trees"] = true,
    ["rockspec"] = true,
+   ["rockspec-format"] = "<ver>",
    ["server"] = "<server>",
    ["skip-pack"] = true,
    ["source"] = true,

--- a/src/luarocks/write_rockspec.lua
+++ b/src/luarocks/write_rockspec.lua
@@ -24,18 +24,19 @@ If a repository URL is given with no version, it creates an 'scm' rock.
 Note that the generated file is a _starting point_ for writing a
 rockspec, and is not guaranteed to be complete or correct.
 
---output=<file>       Write the rockspec with the given filename.
-                      If not given, a file is written in the current
-                      directory with a filename based on given name and version.
---license="<string>"  A license string, such as "MIT/X11" or "GNU GPL v3".
---summary="<txt>"     A short one-line description summary.
---detailed="<txt>"    A longer description string.
---homepage=<url>      Project homepage.
---lua-version=<ver>   Supported Lua versions. Accepted values are "5.1", "5.2",
-                      "5.3", "5.1,5.2", "5.2,5.3", or "5.1,5.2,5.3".
---tag=<tag>           Tag to use. Will attempt to extract version number from it.
---lib=<lib>[,<lib>]   A comma-separated list of libraries that C files need to
-                      link to.
+--output=<file>          Write the rockspec with the given filename.
+                         If not given, a file is written in the current
+                         directory with a filename based on given name and version.
+--license="<string>"     A license string, such as "MIT/X11" or "GNU GPL v3".
+--summary="<txt>"        A short one-line description summary.
+--detailed="<txt>"       A longer description string.
+--homepage=<url>         Project homepage.
+--lua-version=<ver>      Supported Lua versions. Accepted values are "5.1", "5.2",
+                         "5.3", "5.1,5.2", "5.2,5.3", or "5.1,5.2,5.3".
+--rockspec-format=<ver>  Rockspec format version, such as "1.0" or "1.1".
+--tag=<tag>              Tag to use. Will attempt to extract version number from it.
+--lib=<lib>[,<lib>]      A comma-separated list of libraries that C files need to
+                         link to.
 ]]
 
 local function open_file(name)
@@ -246,6 +247,7 @@ function write_rockspec.run(...)
    end
 
    local rockspec = {
+      rockspec_format = flags["rockspec-format"],
       package = name,
       name = name:lower(),
       version = version.."-1",

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -400,6 +400,7 @@ local tests = {
    end,   
    test_write_rockspec = function() return run "$luarocks write_rockspec git://github.com/keplerproject/luarocks" end,
    test_write_rockspec_lib = function() return run '$luarocks write_rockspec git://github.com/mbalmer/luafcgi --lib=fcgi --license="3-clause BSD" --lua-version=5.1,5.2' end,
+   test_write_rockspec_format = function() return run '$luarocks write_rockspec git://github.com/keplerproject/luarocks --rockspec-format=1.1 --lua-version=5.1,5.2' end,
    test_write_rockspec_fullargs = function() return run '$luarocks write_rockspec git://github.com/keplerproject/luarocks --lua-version=5.1,5.2 --license="MIT/X11" --homepage="http://www.luarocks.org" --summary="A package manager for Lua modules"' end,
    fail_write_rockspec_args = function() return run "$luarocks write_rockspec invalid" end,
    fail_write_rockspec_args_url = function() return run "$luarocks write_rockspec http://example.com/invalid.zip" end,

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -492,6 +492,7 @@ test_deps_mode_make_order_sys() { $luarocks build --tree="$testing_tree" lpeg &&
 
 test_write_rockspec() { $luarocks write_rockspec git://github.com/keplerproject/luarocks; }
 test_write_rockspec_lib() { $luarocks write_rockspec git://github.com/mbalmer/luafcgi --lib=fcgi --license="3-clause BSD" --lua-version=5.1,5.2; }
+test_write_rockspec_format() { $luarocks write_rockspec git://github.com/keplerproject/luarocks --rockspec-format=1.1 --lua-version=5.1,5.2; }
 test_write_rockspec_fullargs() { $luarocks write_rockspec git://github.com/keplerproject/luarocks --lua-version=5.1,5.2 --license="MIT/X11" --homepage="http://www.luarocks.org" --summary="A package manager for Lua modules"; }
 fail_write_rockspec_args() { $luarocks write_rockspec invalid; }
 fail_write_rockspec_args_url() { $luarocks write_rockspec http://example.com/invalid.zip; }


### PR DESCRIPTION
Add `--rockspec-format` option for `write_rockspec` command, to be used as `--rockspec-format=1.1`.