### PR TITLE
'config' command does not have a help message

### DIFF
--- a/src/luarocks/config_cmd.lua
+++ b/src/luarocks/config_cmd.lua
@@ -6,7 +6,7 @@ local cfg = require("luarocks.cfg")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
 
-config_cmd.help_summary = "Queries information about the LuaRocks configuration."
+config_cmd.help_summary = "Query information about the LuaRocks configuration."
 config_cmd.help_arguments = "<flag>"
 config_cmd.help = [[
 --lua-incdir     Path to Lua header files.

--- a/src/luarocks/config_cmd.lua
+++ b/src/luarocks/config_cmd.lua
@@ -6,6 +6,22 @@ local cfg = require("luarocks.cfg")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
 
+config_cmd.help_summary = "Queries information about the LuaRocks configuration."
+config_cmd.help_arguments = "<flag>"
+config_cmd.help = [[
+--lua-incdir     Path to Lua header files.
+
+--lua-libdir     Path to Lua library files.
+
+--lua-ver        Lua version (in major.minor format). e.g. 5.1
+
+--system-config  Location of the system config file.
+
+--user-config    Location of the user config file.
+
+--rock-trees     Rocks trees in use. First the user tree, then the system tree.
+]]
+
 local function config_file(conf)
    print(dir.normalize(conf.file))
    if conf.ok then
@@ -39,7 +55,6 @@ function config_cmd.run(...)
    if flags["user-config"] then
       return config_file(conf.user)
    end
-
    if flags["rock-trees"] then
       for _, tree in ipairs(cfg.rocks_trees) do
       	if type(tree) == "string" then

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -50,6 +50,10 @@ local function glob(patt)
    -- TODO
 end
 
+local function touch(filename)
+   -- TODO
+end
+
 local function rm(...)
    for _, filename in ipairs {...} do
       filename = expand_variables(filename)
@@ -397,7 +401,7 @@ local tests = {
       local found = run_get_contents '$luarocks_noecho list --tree="$testing_sys_tree" --porcelain lpeg'
       rm_rf "./lxsh-${verrev_lxsh}"
       return found ~= ""
-   end,   
+   end,
    test_write_rockspec = function() return run "$luarocks write_rockspec git://github.com/keplerproject/luarocks" end,
    test_write_rockspec_lib = function() return run '$luarocks write_rockspec git://github.com/mbalmer/luafcgi --lib=fcgi --license="3-clause BSD" --lua-version=5.1,5.2' end,
    test_write_rockspec_fullargs = function() return run '$luarocks write_rockspec git://github.com/keplerproject/luarocks --lua-version=5.1,5.2 --license="MIT/X11" --homepage="http://www.luarocks.org" --summary="A package manager for Lua modules"' end,
@@ -405,6 +409,33 @@ local tests = {
    fail_write_rockspec_args_url = function() return run "$luarocks write_rockspec http://example.com/invalid.zip" end,
    test_write_rockspec_http = function() return run "$luarocks write_rockspec http://luarocks.org/releases/luarocks-2.1.0.tar.gz --lua-version=5.1" end,
    test_write_rockspec_basedir = function() return run "$luarocks write_rockspec https://github.com/downloads/Olivine-Labs/luassert/luassert-1.2.tar.gz --lua-version=5.1" end,
+
+   fail_config_noflags = function() return run "$luarocks config; " end,
+   test_config_lua_incdir = function() return run "$luarocks config --lua-incdir; " end,
+   test_config_lua_libdir = function() return run "$luarocks config --lua-libdir; " end,
+   test_config_lua_ver = function() return run "$luarocks config --lua-ver; " end,
+   fail_config_system_config = function()
+      return rm "$testing_lrprefix/etc/luarocks/config.lua"
+         and run "$luarocks config --system-config; "
+   end,
+   test_config_system_config = function()
+      local ok = mkdir "$testing_lrprefix/etc/luarocks"
+         and touch "$testing_lrprefix/etc/luarocks/config.lua"
+         and run "$luarocks config --system-config; "
+      rm "$testing_lrprefix/etc/luarocks/config.lua"
+      return ok
+   end,
+   fail_config_system_config_invalid = function()
+      local ok = mkdir "$testing_lrprefix/etc/luarocks"
+         and run "echo 'if if if' > '$testing_lrprefix/etc/luarocks/config.lua' ;"
+         and run "$luarocks config --system-config"
+      rm "$testing_lrprefix/etc/luarocks/config.lua"
+      return ok
+   end,
+   test_config_user_config = function() return run "$luarocks config --user-config; " end,
+   fail_config_user_config = function() return run "LUAROCKS_CONFIG='/missing_file.lua' $luarocks config --user-config; " end,
+   test_config_rock_trees = function() return run "$luarocks config --rock-trees;" end,
+   test_config_help = function() return run "$luarocks help config;" end,
    test_doc = function()
       return run "$luarocks install luarepl"
          and run "$luarocks doc luarepl"

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -508,6 +508,7 @@ fail_config_system_config_invalid() { mkdir -p "$testing_lrprefix/etc/luarocks";
 test_config_user_config() { $luarocks config --user-config; }
 fail_config_user_config() { LUAROCKS_CONFIG="/missing_file.lua" $luarocks config --user-config; }
 test_config_rock_trees() { $luarocks config --rock-trees; }
+test_config_help() { $luarocks help config; }
 
 test_doc() { $luarocks install luarepl; $luarocks doc luarepl; }
 


### PR DESCRIPTION
Consequently, `luarocks help config` crashes:

```
LuaRocks scm, a module deployment system for Lua

NAME

Error: LuaRocks scm bug (please report at https://github.com/keplerproject/luarocks/issues).
/usr/local/share/lua/5.3/luarocks/help.lua:106: attempt to concatenate a nil value (field 'help_summary')
stack traceback:
	/usr/local/share/lua/5.3/luarocks/help.lua:106: in function 'luarocks.help.run'
	(...tail calls...)
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.3/luarocks/command_line.lua:202: in function 'luarocks.command_line.run_command'
	/usr/local/bin/luarocks:34: in main chunk
	[C]: in ?
```