### PR TITLE
Strip only known extensions

### DIFF
--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -170,8 +170,13 @@ function fetch.fetch_and_unpack_rock(rock_file, dest)
 end
 
 function fetch.url_to_base_dir(url)
+   -- for extensions like foo.tar.gz, "gz" is stripped first
+   local known_exts = {}
+   for _, ext in ipairs{"zip", "git", "tgz", "tar", "gz", "bz2"} do
+      known_exts[ext] = ""
+   end
    local base = dir.base_name(url)
-   return base:gsub("%.[^.]*$", ""):gsub("%.tar$", "")
+   return (base:gsub("%.([^.]*)$", known_exts):gsub("%.tar", ""))
 end
 
 --- Back-end function that actually loads the local rockspec.

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -441,5 +441,17 @@ local tests = {
       return run "$luarocks install luarepl"
          and run "$luarocks doc luarepl"
    end,
+
+   -- Tests for https://github.com/keplerproject/luarocks/issues/375
+   test_fetch_base_dir = function()
+      local fetch = require "luarocks.fetch"
+
+      return assert("v0.3" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2/archive/v0.3.zip"))
+         and assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.zip"))
+         and assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.tar.gz"))
+         and assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.tar.bz2"))
+         and assert("parser.moon" == fetch.url_to_base_dir("git://github.com/Cirru/parser.moon"))
+         and assert("v0.3" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2/archive/v0.3"))
+   end
    
 }

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -511,6 +511,19 @@ fail_config_user_config() { LUAROCKS_CONFIG="/missing_file.lua" $luarocks config
 test_config_rock_trees() { $luarocks config --rock-trees; }
 test_config_help() { $luarocks help config; }
 
+# Tests for https://github.com/keplerproject/luarocks/issues/375
+test_fetch_base_dir() { $lua <<EOF
+   local fetch = require "luarocks.fetch"
+
+   assert("v0.3" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2/archive/v0.3.zip"))
+   assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.zip"))
+   assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.tar.gz"))
+   assert("lua-compat-5.2" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2.tar.bz2"))
+   assert("parser.moon" == fetch.url_to_base_dir("git://github.com/Cirru/parser.moon"))
+   assert("v0.3" == fetch.url_to_base_dir("https://github.com/hishamhm/lua-compat-5.2/archive/v0.3"))
+EOF
+}
+
 test_doc() { $luarocks install luarepl; $luarocks doc luarepl; }
 
 # Driver #########################################


### PR DESCRIPTION
In order to address issue #375 only certain extensions are stripped from urls.
Currently: zip, git, tgz, tar, gz, tar.gz and tar.bz2