### PR TITLE
Fix git cloning command when using git+http protocol

### DIFF
--- a/src/luarocks/fetch/git.lua
+++ b/src/luarocks/fetch/git.lua
@@ -68,7 +68,7 @@ function git.get_sources(rockspec, extract, dest_dir, depth)
       if git_can_clone_by_tag(git_cmd) then
          -- The argument to `--branch` can actually be a branch or a tag as of
          -- Git 1.7.10.
-         table.insert(command, 4, "--branch=" .. tag_or_branch)
+         table.insert(command, 3, "--branch=" .. tag_or_branch)
       end
    end
    if not fs.execute(unpack(command)) then


### PR DESCRIPTION
git+http and git+https pass '--' instead of '--depth=1' option.
As '--branch' option was passed after depth, it caused the former
to be interpreted as an extra argument by git. Pass '--branch' first
instead.

Fixes issue brought up in #409