### PR TITLE
Win installer: Unversion LR target path

### DIFF
--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -18,9 +18,8 @@ if not defined LUAROCKS_VER set LUAROCKS_VER=2.2.1
 set LUAROCKS_SHORTV=%LUAROCKS_VER:~0,3%
 
 if not defined LR_EXTERNAL set LR_EXTERNAL=c:\external
-if not defined LUAROCKS_INSTALL set LUAROCKS_INSTALL=%LUA_DIR%\LuaRocks
-if not defined LR_ROOT set LR_ROOT=%LUAROCKS_INSTALL%\%LUAROCKS_SHORTV%
-if not defined LR_SYSTREE set LR_SYSTREE=%LUAROCKS_INSTALL%\systree
+if not defined LR_ROOT set LR_ROOT=%LUA_DIR%\LuaRocks
+if not defined LR_SYSTREE set LR_SYSTREE=%LR_ROOT%\systree
 
 ::
 :: =========================================================
@@ -35,7 +34,7 @@ if not exist %LUA_DIR%\bin\%LUA%.exe call :die "Missing Lua interpreter at %LUA_
 :: =========================================================
 
 cd %APPVEYOR_BUILD_FOLDER%
-call install.bat /LUA %LUA_DIR% /Q /LV %LUA_SHORTV% /P "%LUAROCKS_INSTALL%" /TREE "%LR_SYSTREE%"
+call install.bat /LUA %LUA_DIR% /Q /LV %LUA_SHORTV% /P "%LR_ROOT%" /TREE "%LR_SYSTREE%"
 
 if not exist "%LR_ROOT%" call :die "LuaRocks not found at %LR_ROOT%"
 

--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -47,6 +47,7 @@ set LUA_PATH=%LUA_PATH%;%LR_SYSTREE%\share\lua\%LUA_SHORTV%\?\init.lua
 set LUA_CPATH=%LR_SYSTREE%\lib\lua\%LUA_SHORTV%\?.dll
 
 call luarocks --version || call :die "Error with LuaRocks installation"
+cd && dir
 call luarocks list
 
 

--- a/.appveyor/build.bat
+++ b/.appveyor/build.bat
@@ -47,7 +47,6 @@ set LUA_PATH=%LUA_PATH%;%LR_SYSTREE%\share\lua\%LUA_SHORTV%\?\init.lua
 set LUA_CPATH=%LR_SYSTREE%\lib\lua\%LUA_SHORTV%\?.dll
 
 call luarocks --version || call :die "Error with LuaRocks installation"
-cd && dir
 call luarocks list
 
 

--- a/install.bat
+++ b/install.bat
@@ -487,18 +487,17 @@ local function backup_config_files()
     temppath = os.getenv("temp").."\\LR-config-backup-"..tostring(math.random(10000))
     if exists(temppath) then temppath = nil end
   end
-  print("'"..temppath.."'")
   vars.CONFBACKUPDIR = temppath
   mkdir(vars.CONFBACKUPDIR)
   exec(S[[COPY "$PREFIX\config*.*" "$CONFBACKUPDIR" >NUL]])
-  exec(S[[COPY "$FULL_PREFIX\lua\luarocks\site_config*.*" "$CONFBACKUPDIR" >NUL]])
+  exec(S[[COPY "$PREFIX\lua\luarocks\site_config*.*" "$CONFBACKUPDIR" >NUL]])
 end
 
 -- restore previously backed up config files
 local function restore_config_files()
   if not vars.CONFBACKUPDIR then return end -- there is no backup to restore
   exec(S[[COPY "$CONFBACKUPDIR\config*.*" "$PREFIX" >NUL]])
-  exec(S[[COPY "$CONFBACKUPDIR\site_config*.*" "$FULL_PREFIX\lua\luarocks" >NUL]])
+  exec(S[[COPY "$CONFBACKUPDIR\site_config*.*" "$PREFIX\lua\luarocks" >NUL]])
   -- cleanup
   exec(S[[RD /S /Q "$CONFBACKUPDIR"]])
   vars.CONFBACKUPDIR = nil
@@ -610,11 +609,10 @@ else
 end
 
 vars.PREFIX = vars.PREFIX or os.getenv("PROGRAMFILES")..[[\LuaRocks]]
-vars.FULL_PREFIX = S"$PREFIX\\$VERSION"
-vars.BINDIR = vars.FULL_PREFIX
-vars.LIBDIR = vars.FULL_PREFIX
-vars.LUADIR = S"$FULL_PREFIX\\lua"
-vars.INCDIR = S"$FULL_PREFIX\\include"
+vars.BINDIR = vars.PREFIX
+vars.LIBDIR = vars.PREFIX
+vars.LUADIR = S"$PREFIX\\lua"
+vars.INCDIR = S"$PREFIX\\include"
 vars.LUA_SHORTV = vars.LUA_VERSION:gsub("%.", "")
 
 if INSTALL_LUA then
@@ -659,7 +657,7 @@ print(S[[
 ==========================
 
 Will configure LuaRocks with the following paths:
-LuaRocks        : $FULL_PREFIX
+LuaRocks        : $PREFIX
 Config file     : $CONFIG_FILE
 Rocktree        : $TREE_ROOT
 
@@ -689,18 +687,18 @@ print([[
 -- Install LuaRocks files
 -- ***********************************************************
 
-if exists(vars.FULL_PREFIX) then
+if exists(vars.PREFIX) then
   if not FORCE then
-    die(S"$FULL_PREFIX exists. Use /F to force removal and reinstallation.")
+    die(S"$PREFIX exists. Use /F to force removal and reinstallation.")
   else
     backup_config_files()
-    print(S"Removing $FULL_PREFIX...")
-    exec(S[[RD /S /Q "$FULL_PREFIX"]])
+    print(S"Removing $PREFIX...")
+    exec(S[[RD /S /Q "$PREFIX"]])
     print()
   end
 end
 
-print(S"Installing LuaRocks in $FULL_PREFIX...")
+print(S"Installing LuaRocks in $PREFIX...")
 if not exists(vars.BINDIR) then
 	if not mkdir(vars.BINDIR) then
 		die()
@@ -916,17 +914,17 @@ if REGISTRY then
 	-- expand template with correct path information
 	print()
 	print([[Loading registry information for ".rockspec" files]])
-	exec( S[[win32\lua5.1\bin\lua5.1.exe "$FULL_PREFIX\LuaRocks.reg.lua" "$FULL_PREFIX\LuaRocks.reg.template"]] )
-	exec( S[[regedit /S "$FULL_PREFIX\\LuaRocks.reg"]] )
+	exec( S[[win32\lua5.1\bin\lua5.1.exe "$PREFIX\LuaRocks.reg.lua" "$PREFIX\LuaRocks.reg.template"]] )
+	exec( S[[regedit /S "$PREFIX\\LuaRocks.reg"]] )
 end
 
 -- ***********************************************************
 -- Cleanup
 -- ***********************************************************
 -- remove regsitry related files, no longer needed
-exec( S[[del "$FULL_PREFIX\LuaRocks.reg.*" >NUL]] )
+exec( S[[del "$PREFIX\LuaRocks.reg.*" >NUL]] )
 -- remove pe-parser module
-exec( S[[del "$FULL_PREFIX\pe-parser.lua" >NUL]] )
+exec( S[[del "$PREFIX\pe-parser.lua" >NUL]] )
 
 -- ***********************************************************
 -- Exit handlers 
@@ -946,8 +944,8 @@ Lua interpreter;
   PATH     :   $LUA_BINDIR
   PATHEXT  :   .LUA
 LuaRocks;
-  PATH     :   $FULL_PREFIX
-  LUA_PATH :   $FULL_PREFIX\lua\?.lua;$FULL_PREFIX\lua\?\init.lua
+  PATH     :   $PREFIX
+  LUA_PATH :   $PREFIX\lua\?.lua;$PREFIX\lua\?\init.lua
 Local user rocktree (Note: %APPDATA% is user dependent);
   PATH     :   %APPDATA%\LuaRocks\bin
   LUA_PATH :   %APPDATA%\LuaRocks\share\lua\$LUA_VERSION\?.lua;%APPDATA%\LuaRocks\share\lua\$LUA_VERSION\?\init.lua

--- a/install.bat
+++ b/install.bat
@@ -630,17 +630,23 @@ else
     vars.UNAME_M = get_architecture()  -- can only do when installation was found
 end
 
-local datapath
-if vars.UNAME_M == "x86" then
-	datapath = os.getenv("PROGRAMFILES") .. [[\LuaRocks]]
-else
-	-- our target interpreter is 64bit, so the tree (with binaries) should go into 64bit program files
-	datapath = os.getenv("ProgramW6432") .. [[\LuaRocks]]
+-- check location of system tree
+if not vars.TREE_ROOT then
+  -- no system tree location given, so we need to construct a default value
+  if vars.LUA_BINDIR:lower():match([[([\/]+bin[\/]*)$]]) then
+    -- lua binary is located in a 'bin' subdirectory, so assume
+    -- default Lua layout and match rocktree on top
+    vars.TREE_ROOT = vars.LUA_BINDIR:lower():gsub([[[\/]+bin[\/]*$]], [[\]])
+  else
+    -- no 'bin', so use a named tree next to the Lua executable
+    vars.TREE_ROOT = vars.LUA_BINDIR .. [[\systree]]
+  end
 end
+
+local datapath
 vars.SYSCONFDIR = vars.SYSCONFDIR or vars.PREFIX
 vars.SYSCONFFILENAME = S"config-$LUA_VERSION.lua"
 vars.CONFIG_FILE = vars.SYSCONFDIR.."\\"..vars.SYSCONFFILENAME
-vars.TREE_ROOT = vars.TREE_ROOT or datapath..[[\systree]]
 if SELFCONTAINED then
 	vars.SYSCONFDIR = vars.PREFIX
 	vars.TREE_ROOT = vars.PREFIX..[[\systree]]

--- a/install.bat
+++ b/install.bat
@@ -125,8 +125,9 @@ Installs LuaRocks.
                Default is %PROGRAMFILES%\LuaRocks
 
 Configuring the destinations:
-/TREE [dir]    Root of the local tree of installed rocks.
-               Default is %PROGRAMFILES%\LuaRocks\systree
+/TREE [dir]    Root of the local system tree of installed rocks.
+               Default is {BIN}\..\ if {BIN} ends with '\bin'
+               otherwise it is {BIN}\systree. 
 /SCRIPTS [dir] Where to install commandline scripts installed by
                rocks. Default is {TREE}\bin.
 /LUAMOD [dir]  Where to install Lua modules installed by rocks.

--- a/install.bat
+++ b/install.bat
@@ -97,7 +97,7 @@ local function permission()
 	return exec("net session >NUL 2>&1") -- fails if not admin
 end
 
--- rename file (full path) to backup (name only), appending number if required
+-- rename filename (full path) to backupname (name only), appending number if required
 -- returns the new name (name only)
 local function backup(filename, backupname)
 	local path = filename:match("(.+)%\\.-$").."\\"
@@ -255,7 +255,7 @@ local function check_flags()
 			die("Cannot combine option /L with any of /LUA /BIN /LIB /INC")
 		end
 		if vars.LUA_VERSION ~= "5.1" then
-			die("Bundled Lua version is 5.1, cannot install 5.2")
+			die("Bundled Lua version is 5.1, cannot install "..vars.LUA_VERSION)
 		end
 	end
 	if vars.LUA_VERSION ~= "5.1" then

--- a/install.bat
+++ b/install.bat
@@ -122,9 +122,6 @@ local function print_help()
 Installs LuaRocks.
 
 /P [dir]       Where to install LuaRocks. 
-               Note that version; $VERSION, will be appended to this
-               path, so "/P c:\luarocks\" will install in 
-               "c:\luarocks\$VERSION\"
                Default is %PROGRAMFILES%\LuaRocks
 
 Configuring the destinations:

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -374,7 +374,7 @@ local defaults = {
 }
 
 if cfg.platforms.windows then
-   local full_prefix = (site_config.LUAROCKS_PREFIX or (os.getenv("PROGRAMFILES")..[[\LuaRocks]])).."\\"..cfg.major_version
+   local full_prefix = (site_config.LUAROCKS_PREFIX or (os.getenv("PROGRAMFILES")..[[\LuaRocks]]))
    extra_luarocks_module_dir = full_prefix.."\\lua\\?.lua"
 
    home_config_file = home_config_file and home_config_file:gsub("\\","/")

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -228,17 +228,33 @@ end
 if not site_config.LUAROCKS_FORCE_CONFIG then
   
    home_config_file_default = home_config_dir.."/config-"..cfg.lua_version..".lua"
-   local list = {
-      os.getenv("LUAROCKS_CONFIG_" .. version_suffix) or os.getenv("LUAROCKS_CONFIG"),
-      home_config_file_default,
-      home_config_dir.."/config.lua",
-   }
-   -- first entry might be a silent nil, check and remove if so
-   if not list[1] then table.remove(list, 1) end
    
-   home_config_file = load_config_file(list)
-   home_config_ok = (home_config_file ~= nil)
+   local config_env_var   = "LUAROCKS_CONFIG_" .. version_suffix
+   local config_env_value = os.getenv(config_env_var)
+   if not config_env_value then
+      config_env_var   = "LUAROCKS_CONFIG"
+      config_env_value = os.getenv(config_env_var)
+   end
+   
+   -- first try environment provided file, so we can explicitly warn when it is missing
+   if config_env_value then 
+      local list = { config_env_value }
+      home_config_file = load_config_file(list)
+      home_config_ok = (home_config_file ~= nil)
+      if not home_config_ok then
+         io.stderr:write("Warning: could not load configuration file `"..config_env_value.."` given in environment variable "..config_env_var.."\n")
+      end
+   end
 
+   -- try the alternative defaults if there was no environment specified file or it didn't work
+   if not home_config_ok then
+      local list = {
+         home_config_file_default,
+         home_config_dir.."/config.lua",
+      }
+      home_config_file = load_config_file(list)
+      home_config_ok = (home_config_file ~= nil)
+   end
 end
 
 


### PR DESCRIPTION
This PR fixes the installer to use a non-versioned path for the LR installation (fixes #151). As discussed here https://github.com/keplerproject/luarocks/issues/403#issuecomment-118026700 . It also fixes the retainment of the existing config files.

One problem though; because the LR path is moving one level up, the system rock tree is now in the same path. e.g. default used to be `c:\program files (x86)\luarocks\2.2` and now is `c:\program files (x86)\luarocks`. This means that when deleting that existing directory upon installation, the default location of the system tree; `c:\program files (x86)\luarocks\systree`, is now also deleted.

iirc correctly the system tree used to be installed in the Lua directories, not the LuaRocks directories. Some 2 years ago this was changed, but with hind sight that seems a bad change, so maybe that should be reverted.

For now; this is for discussion only, do not merge yet, until the systree location issue is resolved.
