### PR TITLE
ci: updates appveyor config to use VS2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 version: 2.2.1.{build}-test
 
-os:
-- Windows Server 2012 R2
-
 shallow_clone: true
 
 environment:
@@ -17,8 +14,8 @@ environment:
 
 init:
 # Setup Lua development/build environment
-# Make VS 2013 command line tools available
-- call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %platform%
+# Make VS 2015 command line tools available
+- call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %platform%
 
 install:
 # Setup Lua development/build environment


### PR DESCRIPTION
This PR sets the CI build against Visual Studio 2015.

AppVeyor uses the full-featured free-for-OSS edition of VS2015: Community Edition (http://visualstudio.com/community/). VS2015 packs version of `cl.exe` which compiles C99 (finally), C++1[1/4/7] features + the XP support: http://blogs.msdn.com/b/vcblog/archive/2015/06/19/c-11-14-17-features-in-vs-2015-rtm.aspx. So many `_MSC_VER` directives can be purged away.