### PR TITLE
Fix patch error message when source is different

### DIFF
--- a/src/luarocks/tools/patch.lua
+++ b/src/luarocks/tools/patch.lua
@@ -455,16 +455,15 @@ local function find_hunks(file, hunks)
 end
 
 local function check_patched(file, hunks)
-  local matched = true
   local lineno = 1
   local ok, err = pcall(function()
     if #file == 0 then
-      error 'nomatch'
+      error('nomatch', 0)
     end
     for hno, h in ipairs(hunks) do
       -- skip to line just before hunk starts
       if #file < h.starttgt then
-         error 'nomatch'
+        error('nomatch', 0)
       end
       lineno = h.starttgt
       for _, hline in ipairs(h.text) do
@@ -473,22 +472,18 @@ local function check_patched(file, hunks)
           local line = file[lineno]
           lineno = lineno + 1
           if #line == 0 then
-            error 'nomatch'
+            error('nomatch', 0)
           end
           if endlstrip(line) ~= endlstrip(hline:sub(2)) then
             warning(format("file is not patched - failed hunk: %d", hno))
-            error 'nomatch'
+            error('nomatch', 0)
           end
         end
       end
     end
   end)
-  if err == 'nomatch' then
-    matched = false
-  end
-    -- todo: display failed hunk, i.e. expected/found
-
-  return matched
+  -- todo: display failed hunk, i.e. expected/found
+  return err ~= 'nomatch'
 end
 
 local function patch_hunks(srcname, tgtname, hunks)


### PR DESCRIPTION
`check_patched()` relies on throwing and catching string 'nomatch'. Pass 0 as the second argument for `error()` when throwing to avoid location info being added to the message.

Fixes lack of error when patch should fail with "source is different" error.
