### PR TITLE
Fix `find_program` function to be less fragile

### DIFF
--- a/configure
+++ b/configure
@@ -71,26 +71,7 @@ EOF
 # Helper functions
 
 find_program() {
-   path="$PATH"
-   item="`echo "$path" | sed 's/\([^:]*\):.*/\1/'`"
-   path="`echo "$path" | sed -n 's/[^:]*::*\(.*\)/\1/p'`"
-   found="no"
-   while [ -n "$item" ]
-   do
-      if [ -f "$item/$1" ]
-      then
-         found="yes"
-         break
-      fi
-      item="`echo "$path" | sed 's/\([^:]*\):.*/\1/'`"
-      path="`echo "$path" | sed -n 's/[^:]*::*\(.*\)/\1/p'`"
-   done
-   if [ "$found" = "yes" ]
-   then
-      echo "$item"
-   else
-      echo ""
-   fi
+    which "$1" 2>/dev/null
 }
 
 die() {

--- a/configure
+++ b/configure
@@ -71,7 +71,7 @@ EOF
 # Helper functions
 
 find_program() {
-    which "$1" 2>/dev/null
+    command -v "$1" 2>/dev/null
 }
 
 die() {


### PR DESCRIPTION
Look for executable path using system utility `which` instead of fragile regular expressions. See #447  for details. Also see discussion in [neovim issues](https://github.com/neovim/neovim/issues/3620#issuecomment-154757577).