### PR TITLE
Improve builtin build backend errors

### DIFF
--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -174,7 +174,7 @@ function builtin.run(rockspec)
       --TODO EXEWRAPPER
    end
 
-   local ok = true
+   local ok, err
    local built_modules = {}
    local luadir = path.lua_dir(rockspec.name, rockspec.version)
    local libdir = path.lib_dir(rockspec.name, rockspec.version)
@@ -236,11 +236,10 @@ function builtin.run(rockspec)
             end
             table.insert(objects, object)
          end
-         if not ok then break end
          local module_name = name:match("([^.]*)$").."."..util.matchquote(cfg.lib_extension)
          if moddir ~= "" then
             module_name = dir.path(moddir, module_name)
-            local ok, err = fs.make_dir(moddir)
+            ok, err = fs.make_dir(moddir)
             if not ok then return nil, err end
          end
          built_modules[module_name] = dir.path(libdir, module_name)
@@ -252,13 +251,13 @@ function builtin.run(rockspec)
    end
    for name, dest in pairs(built_modules) do
       fs.make_dir(dir.dir_name(dest))
-      ok = fs.copy(name, dest)
+      ok, err = fs.copy(name, dest)
       if not ok then
-         return nil, "Failed installing "..name.." in "..dest
+         return nil, "Failed installing "..name.." in "..dest..": "..err
       end
    end
    if fs.is_dir("lua") then
-      local ok, err = fs.copy_contents("lua", luadir)
+      ok, err = fs.copy_contents("lua", luadir)
       if not ok then
          return nil, "Failed copying contents of 'lua' directory: "..err
       end

--- a/src/luarocks/build/builtin.lua
+++ b/src/luarocks/build/builtin.lua
@@ -202,7 +202,7 @@ function builtin.run(rockspec)
    for name, info in pairs(build.modules) do
       local moddir = path.module_to_path(name)
       if type(info) == "string" then
-         local ext = info:match(".([^.]+)$")
+         local ext = info:match("%.([^.]+)$")
          if ext == "lua" then
             local filename = dir.base_name(info)
             if info:match("init%.lua$") and not name:match("%.init$") then
@@ -226,7 +226,7 @@ function builtin.run(rockspec)
          if info[1] then sources = info end
          if type(sources) == "string" then sources = {sources} end
          for _, source in ipairs(sources) do
-            local object = source:gsub(".[^.]*$", "."..cfg.obj_extension)
+            local object = source:gsub("%.[^.]*$", "."..cfg.obj_extension)
             if not object then
                object = source.."."..cfg.obj_extension
             end


### PR DESCRIPTION
This improves errors in two cases:

* When a file name for a module doesn't have an extension: currently `.o` is shown in the error message instead of actual name.
* When a file for a Lua module doesn't exist: currently failure cause isn't displayed.

To be merged after 2.3.0 is released, I suppose.
