### PR TITLE
Add git+ssh support to the fetchers.

### DIFF
--- a/Makefile.setup.inc
+++ b/Makefile.setup.inc
@@ -16,5 +16,5 @@ help.lua util.lua index.lua cache.lua refresh_cache.lua loader.lua \
 admin_remove.lua fetch/hg.lua fetch/git_file.lua new_version.lua lint.lua \
 purge.lua path.lua path_cmd.lua write_rockspec.lua doc.lua upload.lua \
 upload/api.lua upload/multipart.lua fetch/git_http.lua fetch/hg_http.lua \
-fetch/hg_https.lua fetch/hg_ssh.lua fetch/git_https.lua
+fetch/hg_https.lua fetch/hg_ssh.lua fetch/git_https.lua fetch/git_ssh.lua
 

--- a/src/luarocks/fetch/git_ssh.lua
+++ b/src/luarocks/fetch/git_ssh.lua
@@ -2,9 +2,12 @@
 --- Fetch back-end for retrieving sources from Git repositories
 -- that use ssh:// transport. For example, for fetching a repository
 -- that requires the following command line:
--- `git clone git@example.com:username/foo.git
+-- `git clone ssh://git@example.com/path/foo.git
 -- you can use this in the rockspec:
--- source = { url = "git+ssh://git@example.com:username/foo.git" }
+-- source = { url = "git+ssh://git@example.com/path/foo.git" }
+-- It also handles scp-style ssh urls: git@example.com:path/foo.git,
+-- but you have to prepend the "git+ssh://" and why not use the "newer"
+-- style anyway?
 local git_ssh = {}
 
 local git = require("luarocks.fetch.git")
@@ -17,7 +20,13 @@ local git = require("luarocks.fetch.git")
 -- the fetched source tarball and the temporary directory created to
 -- store it; or nil and an error message.
 function git_ssh.get_sources(rockspec, extract, dest_dir)
-   rockspec.source.url = rockspec.source.url:gsub("^git.ssh://", "")
+   rockspec.source.url = rockspec.source.url:gsub("^git.", "")
+
+   -- Handle old-style scp-like git ssh urls
+   if rockspec.source.url:match("ssh://[^/]+:[^%d]") then
+      rockspec.source.url = rockspec.source.url:gsub("^ssh://", "")
+   end
+
    return git.get_sources(rockspec, extract, dest_dir, "--")
 end
 

--- a/src/luarocks/fetch/git_ssh.lua
+++ b/src/luarocks/fetch/git_ssh.lua
@@ -1,0 +1,24 @@
+
+--- Fetch back-end for retrieving sources from Git repositories
+-- that use ssh:// transport. For example, for fetching a repository
+-- that requires the following command line:
+-- `git clone git@example.com:username/foo.git
+-- you can use this in the rockspec:
+-- source = { url = "git+ssh://git@example.com:username/foo.git" }
+local git_ssh = {}
+
+local git = require("luarocks.fetch.git")
+
+--- Fetch sources for building a rock from a local Git repository.
+-- @param rockspec table: The rockspec table
+-- @param extract boolean: Unused in this module (required for API purposes.)
+-- @param dest_dir string or nil: If set, will extract to the given directory.
+-- @return (string, string) or (nil, string): The absolute pathname of
+-- the fetched source tarball and the temporary directory created to
+-- store it; or nil and an error message.
+function git_ssh.get_sources(rockspec, extract, dest_dir)
+   rockspec.source.url = rockspec.source.url:gsub("^git.ssh://", "")
+   return git.get_sources(rockspec, extract, dest_dir, "--")
+end
+
+return git_ssh


### PR DESCRIPTION
This adds support for git+ssh, which is used for authenticated repo access by at least Github and bitbucket.  I'm not sure master is the right place to put this, but since it adds functionality rather than modifies it, I figure it's non-breaking?