### PR TITLE
avoid "missing dependency" errors for defaults

### DIFF
--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -727,7 +727,10 @@ function deps.scan_deps(results, missing, manifest, name, version, deps_mode)
       end
       dependencies_name[version] = rockspec.dependencies
    else
-      rockspec = { dependencies = deplist, rocks_provided = {} }
+      rockspec = {
+         dependencies = deplist,
+         rocks_provided = setmetatable({}, { __index = cfg.rocks_provided_3_0 })
+      }
    end
    local matched, failures = deps.match_deps(rockspec, nil, deps_mode)
    results[name] = results


### PR DESCRIPTION
Warning: I am just trying to figure out the changes in the luarocks-3 branch, so I am absolutely not sure of this fix :)

The issue is that, if I try to install a rock, the default dependencies such as Lua itself are not taken into account:

```
Missing dependency for luaposix 33.3.1-1: bit32 
Missing dependency for luaposix 33.3.1-1: lua >= 5.1, < 5.4
Missing dependency for flu 20150331-1: lua >= 5.1, < 6
Missing dependency for mirrorfs scm-1: bit32 
Missing dependency for mirrorfs scm-1: lua >= 5.1, < 5.4
Missing dependency for mirrorfs scm-1: lua >= 5.3
Missing dependency for mirrorfs scm-1: lua >= 5.1, < 6
```

This fix avoids this. Not sure if there is a better way to do it.