### PR TITLE
[WIP] Internal support for upgrade and more

### DIFF
--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -160,9 +160,11 @@ end
 -- "all" for all trees, "order" for all trees with priority >= the current default,
 -- "none" for no trees.
 -- @param build_only_deps boolean: true to build the listed dependencies only.
+-- @param deps_install_mode string: Dependency install mode: "install" to always reinstall,
+-- "upgrade" to upgrade to latest version, "satisfy" to only install if missing.
 -- @return (string, string) or (nil, string, [string]): Name and version of
 -- installed rock if succeeded or nil and an error message followed by an error code.
-function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_mode, build_only_deps)
+function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_mode, build_only_deps, deps_install_mode)
    assert(type(rockspec_file) == "string")
    assert(type(need_to_fetch) == "boolean")
 
@@ -178,7 +180,7 @@ function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_m
    if deps_mode == "none" then
       util.printerr("Warning: skipping dependency checks.")
    else
-      local ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode)
+      local ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode, deps_install_mode)
       if err then
          return nil, err, errcode
       end
@@ -351,9 +353,12 @@ end
 -- "one" for the current default tree, "all" for all trees,
 -- "order" for all trees with priority >= the current default, "none" for no trees.
 -- @param build_only_deps boolean: true to build the listed dependencies only.
+-- @param deps_install_mode string: Dependency install mode: "install" to always reinstall,
+-- "upgrade" to upgrade to latest version, "satisfy" to only install if missing.
 -- @return boolean or (nil, string, [string]): True if build was successful,
+
 -- or false and an error message and an optional error code.
-function build.build_rock(rock_file, need_to_fetch, deps_mode, build_only_deps)
+function build.build_rock(rock_file, need_to_fetch, deps_mode, build_only_deps, deps_install_mode)
    assert(type(rock_file) == "string")
    assert(type(need_to_fetch) == "boolean")
 
@@ -366,7 +371,7 @@ function build.build_rock(rock_file, need_to_fetch, deps_mode, build_only_deps)
    local rockspec_file = path.rockspec_name_from_rock(rock_file)
    ok, err = fs.change_dir(unpack_dir)
    if not ok then return nil, err end
-   ok, err, errcode = build.build_rockspec(rockspec_file, need_to_fetch, false, deps_mode, build_only_deps)
+   ok, err, errcode = build.build_rockspec(rockspec_file, need_to_fetch, false, deps_mode, build_only_deps, deps_install_mode)
    fs.pop_dir()
    return ok, err, errcode
 end

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -480,13 +480,13 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
       for _, dep in pairs(missing) do
          -- Double-check in case dependency was filled during recursion.
          if not match_dep(dep, nil, deps_mode) then
-            local rock = search.find_suitable_rock(dep)
-            if not rock then
+            local rock_url = search.find_suitable_rock(dep)
+            if not rock_url then
                return nil, "Could not satisfy dependency: "..deps.show_dep(dep)
             end
-            local ok, err, errcode = install.run(rock)
+            local ok, err = install.install_by_url(rock_url)
             if not ok then
-               return nil, "Failed installing dependency: "..rock.." - "..err, errcode
+               return nil, "Failed installing dependency: "..rock_url.." - "..err
             end
          end
       end

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -429,7 +429,9 @@ function deps.diagnose_dependency(dep, deps_mode, install_mode)
    return installed and "upgrade" or "new"
 end
 
-local function list_deps(dependencies, actions, action, header)
+local function list_deps(dependencies, actions, action, header, parent)
+   local ok = true
+
    for _, dep in ipairs(dependencies) do
       if actions[dep] == action then
          if header then
@@ -438,8 +440,20 @@ local function list_deps(dependencies, actions, action, header)
          end
 
          util.printerr(deps.show_dep(dep))
+
+         if action and dep.constraints[1] and dep.constraints[1].no_upgrade then
+            util.printerr("This version of "..parent.." is designed for use with")
+            util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
+            util.printerr("automatically. Please upgrade "..dep.name.." with")
+            util.printerr("   luarocks install "..dep.name)
+            util.printerr("or choose an older version of "..parent.." with")
+            util.printerr("   luarocks search "..parent)
+            ok = false
+         end
       end
    end
+
+   return ok
 end
 
 --- Return a set of values of a table.
@@ -498,7 +512,7 @@ function deps.fulfill_dependencies(rockspec, deps_mode, install_mode)
    for _, dep in ipairs(rockspec.dependencies) do
       local action = deps.diagnose_dependency(dep, deps_mode, install_mode)
 
-      if action then
+      if action or (install_mode ~= "satisfy" and not cfg.rocks_provided[dep.name]) then
          table.insert(deps_to_install, dep)
          actions[dep] = action
       end
@@ -509,43 +523,39 @@ function deps.fulfill_dependencies(rockspec, deps_mode, install_mode)
    end
 
    local header = " dependencies for "..rockspec.name.." "..rockspec.version..":"
-   list_deps(deps_to_install, actions, "new", "Missing"..header)
-   list_deps(deps_to_install, actions, "upgrade", "Upgrading"..header)
-   list_deps(deps_to_install, actions, "reinstall", "Reinstalling"..header)
+   local ok_new = list_deps(deps_to_install, actions, "new", "Missing"..header, rockspec.name)
+   local ok_upgrade = list_deps(deps_to_install, actions, "upgrade", "Upgrading"..header, rockspec.name)
+   local ok_reinstall = list_deps(deps_to_install, actions, "reinstall", "Reinstalling"..header, rockspec.name)
+   local ok_recurse = list_deps(deps_to_install, actions, nil, "Up-to-date"..header, rockspec.name)
+
+   if not (ok_new and ok_upgrade and ok_reinstall and ok_recurse) then
+      return nil, "Failed matching dependencies."
+   end
 
    if #deps_to_install > 0 then
       util.printerr()
    end
 
-   local have_unupgradable_dep = false
-
    for _, dep in ipairs(deps_to_install) do
-      if dep.constraints[1] and dep.constraints[1].no_upgrade then
-         util.printerr("This version of "..rockspec.name.." is designed for use with")
-         util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
-         util.printerr("automatically. Please upgrade "..dep.name.." with")
-         util.printerr("   luarocks install "..dep.name)
-         util.printerr("or choose an older version of "..rockspec.name.." with")
-         util.printerr("   luarocks search "..rockspec.name)
-         have_unupgradable_dep = true
-      end
-   end
-
-   if have_unupgradable_dep then
-      return nil, "Failed matching dependencies."
-   end
-
-   for _, dep in ipairs(deps_to_install) do
-      -- Double-check in case dependency was filled during recursion.
-      if deps.diagnose_dependency(dep, deps_mode, install_mode) then
-         local rock_url = search.find_suitable_rock(dep)
-         if not rock_url then
-            return nil, "Could not satisfy dependency: "..deps.show_dep(dep)
+      if actions[dep] then
+         -- Double-check in case dependency was filled during recursion.
+         if deps.diagnose_dependency(dep, deps_mode, install_mode) then
+            local rock_url = search.find_suitable_rock(dep)
+            if not rock_url then
+               return nil, "Could not satisfy dependency: "..deps.show_dep(dep)
+            end
+            local ok, err = install.install_by_url(rock_url, {deps_install_mode = install_mode})
+            if not ok then
+               return nil, "Failed installing dependency: "..rock_url.." - "..err
+            end
          end
-         local ok, err = install.install_by_url(rock_url, {deps_install_mode = install_mode})
-         if not ok then
-            return nil, "Failed installing dependency: "..rock_url.." - "..err
-         end
+      else
+         -- Don't reinstall the dependency, only recurse.
+         local fetch = require("luarocks.fetch")
+         local installed = match_dep(dep, nil, deps_mode)
+         local dep_rockspec = fetch.load_rockspec(path.rockspec_file(installed.name, installed.version))
+         local ok, err = deps.fulfill_dependencies(dep_rockspec, deps_mode, install_mode)
+         if not ok then return nil, err end
       end
    end
 

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -395,6 +395,53 @@ function deps.match_deps(rockspec, blacklist, deps_mode)
    return matched, missing, no_upgrade
 end
 
+--- Decide what to do about a dependency.
+-- @param dep: dependency table.
+-- @param install_mode: string "install", "upgrade" or "satisfy".
+-- "install" means: always install latest possible version.
+-- "upgrade" means: install latest possible version unless it's already installed.
+-- "satisfy" means: install latest possible version unless any version is installed.
+-- @return nil if installation is not needed, else string describing installation action
+-- (can be "new", "upgrade" or "reinstall").
+function deps.diagnose_dependency(dep, deps_mode, install_mode)
+   assert(type(dep) == "table")
+   local installed = match_dep(dep, nil, deps_mode)
+
+   if installed and (install_mode == "satisfy" or cfg.rocks_provided[dep.name]) then
+      return
+   end
+
+   if install_mode == "install" then
+      return installed and "reinstall" or "new"
+   end
+
+   if installed and install_mode == "upgrade" then
+      local search = require("luarocks.search")
+      local url, latest_version = search.find_suitable_rock(dep)
+
+      if url and not deps.compare_versions(latest_version, installed.version) then
+         return
+      end
+
+      -- If there was an error in search, fallthrough, it will be detected when attempting to install.
+   end
+
+   return installed and "upgrade" or "new"
+end
+
+local function list_deps(dependencies, actions, action, header)
+   for _, dep in ipairs(dependencies) do
+      if actions[dep] == action then
+         if header then
+            util.printerr(header)
+            header = nil
+         end
+
+         util.printerr(deps.show_dep(dep))
+      end
+   end
+end
+
 --- Return a set of values of a table.
 -- @param tbl table: The input table.
 -- @return table: The array of keys.
@@ -413,8 +460,8 @@ end
 -- @return boolean or (nil, string, [string]): True if no errors occurred, or
 -- nil and an error message if any test failed, followed by an optional
 -- error code.
-function deps.fulfill_dependencies(rockspec, deps_mode)
-
+function deps.fulfill_dependencies(rockspec, deps_mode, install_mode)
+   install_mode = install_mode or "satisfy"
    local search = require("luarocks.search")
    local install = require("luarocks.install")
 
@@ -445,52 +492,63 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
       end
    end
 
-   local _, missing, no_upgrade = deps.match_deps(rockspec, nil, deps_mode)
+   local deps_to_install = {}
+   local actions = {}
 
-   if next(no_upgrade) then
-      util.printerr("Missing dependencies for "..rockspec.name.." "..rockspec.version..":")
-      for _, dep in pairs(no_upgrade) do
-         util.printerr(deps.show_dep(dep))
+   for _, dep in ipairs(rockspec.dependencies) do
+      local action = deps.diagnose_dependency(dep, deps_mode, install_mode)
+
+      if action then
+         table.insert(deps_to_install, dep)
+         actions[dep] = action
       end
-      if next(missing) then
-         for _, dep in pairs(missing) do
-            util.printerr(deps.show_dep(dep))
-         end
-      end
+   end
+
+   if #deps_to_install > 0 then
       util.printerr()
-      for _, dep in pairs(no_upgrade) do
+   end
+
+   local header = " dependencies for "..rockspec.name.." "..rockspec.version..":"
+   list_deps(deps_to_install, actions, "new", "Missing"..header)
+   list_deps(deps_to_install, actions, "upgrade", "Upgrading"..header)
+   list_deps(deps_to_install, actions, "reinstall", "Reinstalling"..header)
+
+   if #deps_to_install > 0 then
+      util.printerr()
+   end
+
+   local have_unupgradable_dep = false
+
+   for _, dep in ipairs(deps_to_install) do
+      if dep.constraints[1] and dep.constraints[1].no_upgrade then
          util.printerr("This version of "..rockspec.name.." is designed for use with")
          util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
          util.printerr("automatically. Please upgrade "..dep.name.." with")
          util.printerr("   luarocks install "..dep.name)
          util.printerr("or choose an older version of "..rockspec.name.." with")
          util.printerr("   luarocks search "..rockspec.name)
+         have_unupgradable_dep = true
       end
+   end
+
+   if have_unupgradable_dep then
       return nil, "Failed matching dependencies."
    end
 
-   if next(missing) then
-      util.printerr()
-      util.printerr("Missing dependencies for "..rockspec.name..":")
-      for _, dep in pairs(missing) do
-         util.printerr(deps.show_dep(dep))
-      end
-      util.printerr()
-
-      for _, dep in pairs(missing) do
-         -- Double-check in case dependency was filled during recursion.
-         if not match_dep(dep, nil, deps_mode) then
-            local rock_url = search.find_suitable_rock(dep)
-            if not rock_url then
-               return nil, "Could not satisfy dependency: "..deps.show_dep(dep)
-            end
-            local ok, err = install.install_by_url(rock_url)
-            if not ok then
-               return nil, "Failed installing dependency: "..rock_url.." - "..err
-            end
+   for _, dep in ipairs(deps_to_install) do
+      -- Double-check in case dependency was filled during recursion.
+      if deps.diagnose_dependency(dep, deps_mode, install_mode) then
+         local rock_url = search.find_suitable_rock(dep)
+         if not rock_url then
+            return nil, "Could not satisfy dependency: "..deps.show_dep(dep)
+         end
+         local ok, err = install.install_by_url(rock_url, {deps_install_mode = install_mode})
+         if not ok then
+            return nil, "Failed installing dependency: "..rock_url.." - "..err
          end
       end
    end
+
    return true
 end
 

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -222,9 +222,8 @@ function install.install_by_name(name, options)
          util.printout("Latest possible version of "..name.." already installed.")
       end
 
-      if options.deps_install_mode and options.deps_install_mode ~= "satisfy" then
-         local ok, err = deps.process_rock_dependencies(dep, deps_mode, options.deps_install_mode)
-         if not ok then return nil, err end
+      if deps_mode ~= "none" and options.deps_install_mode and options.deps_install_mode ~= "satisfy" then
+         return deps.process_rock_dependencies(dep, deps_mode, options.deps_install_mode)
       end
 
       return true

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -38,7 +38,7 @@ or a filename of a locally available rock.
 -- "order" for all trees with priority >= the current default, "none" for no trees.
 -- @return (string, string) or (nil, string, [string]): Name and version of
 -- installed rock if succeeded or nil and an error message followed by an error code.
-function install.install_binary_rock(rock_file, deps_mode)
+function install.install_binary_rock(rock_file, deps_mode, deps_install_mode)
    assert(type(rock_file) == "string")
 
    local name, version, arch = path.parse_name(rock_file)
@@ -80,7 +80,7 @@ function install.install_binary_rock(rock_file, deps_mode)
    end
 
    if deps_mode ~= "none" then
-      ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode)
+      ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode, deps_install_mode)
       if err then return nil, err, errcode end
    end
 
@@ -119,7 +119,7 @@ end
 -- @return (string, string) or (nil, string, [string]): Name and version of
 -- the rock whose dependencies were installed if succeeded or nil and an error message 
 -- followed by an error code.
-function install.install_binary_rock_deps(rock_file, deps_mode)
+function install.install_binary_rock_deps(rock_file, deps_mode, install_mode)
    assert(type(rock_file) == "string")
 
    local name, version, arch = path.parse_name(rock_file)
@@ -139,7 +139,7 @@ function install.install_binary_rock_deps(rock_file, deps_mode)
       return nil, "Failed loading rockspec for installed package: "..err, errcode
    end
 
-   ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode)
+   ok, err, errcode = deps.fulfill_dependencies(rockspec, deps_mode, install_mode)
    if err then return nil, err, errcode end
 
    util.printout()
@@ -151,6 +151,8 @@ end
 --- Install a rock by url.
 -- @param url string: rock or rockspec url or path.
 -- @param options table (optional): table with command-line flags.
+-- Can also contain deps_install_mode applied to the rock dependencies (recursively):
+-- "install" to always reinstall, "upgrade" to upgrade to latest version, "satisfy" to only install if missing.
 -- @return (string, string) or (nil, string): name and version
 -- of installed rock if successful, nil and error message otherwise.
 function install.install_by_url(url, options)
@@ -166,15 +168,15 @@ function install.install_by_url(url, options)
       local build_only_deps = options["only-deps"]
 
       if url:match("%.rockspec$") then
-         name, version = build.build_rockspec(url, true, false, deps_mode, build_only_deps)
+         name, version = build.build_rockspec(url, true, false, deps_mode, build_only_deps, options.deps_install_mode)
       else
-         name, version = build.build_rock(url, false, deps_mode, build_only_deps)
+         name, version = build.build_rock(url, false, deps_mode, build_only_deps, options.deps_install_mode)
       end
    elseif url:match("%.rock$") then
       if options["only-deps"] then
-         name, version = install.install_binary_rock_deps(url, deps_mode)
+         name, version = install.install_binary_rock_deps(url, deps_mode, options.deps_install_mode)
       else
-         name, version = install.install_binary_rock(url, deps_mode)
+         name, version = install.install_binary_rock(url, deps_mode, options.deps_install_mode)
       end
    else
       return nil, "Don't know what to do with "..url

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -223,11 +223,7 @@ function install.install_by_name(name, options)
       end
 
       if options.deps_install_mode and options.deps_install_mode ~= "satisfy" then
-         local manif_core = require("luarocks.manif_core")
-         local versions = manif_core.get_versions(name, deps_mode)
-         local version = versions[#versions]
-         local rockspec = fetch.load_rockspec(path.rockspec_file(name, version))
-         local ok, err = deps.fulfill_dependencies(rockspec, deps_mode, options.deps_install_mode)
+         local ok, err = deps.process_rock_dependencies(dep, deps_mode, options.deps_install_mode)
          if not ok then return nil, err end
       end
 

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -222,6 +222,15 @@ function install.install_by_name(name, options)
          util.printout("Latest possible version of "..name.." already installed.")
       end
 
+      if options.deps_install_mode and options.deps_install_mode ~= "satisfy" then
+         local manif_core = require("luarocks.manif_core")
+         local versions = manif_core.get_versions(name, deps_mode)
+         local version = versions[#versions]
+         local rockspec = fetch.load_rockspec(path.rockspec_file(name, version))
+         local ok, err = deps.fulfill_dependencies(rockspec, deps_mode, options.deps_install_mode)
+         if not ok then return nil, err end
+      end
+
       return true
    end
 

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -244,11 +244,11 @@ function search.make_query(name, version)
    return query
 end
 
---- Get the URL for the latest in a set of versions.
+--- Get the URL and version for the latest in a set of versions.
 -- @param name string: The package name to be used in the URL.
 -- @param versions table: An array of version informations, as stored
 -- in search results tables.
--- @return string or nil: the URL for the latest version if one could
+-- @return (string, string) or nil: the URL and the version for the latest version if one could
 -- be picked, or nil.
 local function pick_latest_version(name, versions)
    assert(type(name) == "string")
@@ -269,14 +269,14 @@ local function pick_latest_version(name, versions)
             pick = i
          end
       end
-      return path.make_url(items[pick].repo, name, version, items[pick].arch)
+      return path.make_url(items[pick].repo, name, version, items[pick].arch), version
    end
    return nil
 end
 
 --- Attempt to get a single URL for a given search.
 -- @param query table: A dependency query.
--- @return string or table or (nil, string): URL for matching rock if
+-- @return (string, string) or table or (nil, string): URL and version for matching rock if
 -- a single one was found, a table of candidates if it could not narrow to
 -- a single result, or nil followed by an error message.
 function search.find_suitable_rock(query)


### PR DESCRIPTION
This PR implements a new internal option that specifies how a dependency is resolved:

* "install": always install the latest possible version;
* "upgrade": install the latest possible version unless it's already installed;
* "satisfy": install the latest possible version unless some (matching) version is already installed.

If we interpret `luarocks install foo` as "satisfy dependency `foo`" and `luarocks install foo 2.0` as "satisfy dependency `foo == 2.0`", then various combinations of upgrading/installation logic are expressed as pairs of "install", "upgrade" or "satisfy": the first one for the "root" rock (foo in this example) and the other for all its dependencies, recursively.

So, currently LuaRocks uses ("install", "satisfy"). I think it would be useful to support all the combinations. E.g. ("upgrade", "satisfy") means "upgrade a rock"; ("satisfy", "satisfy") is a lazy install that doesn't hit the network if the rock is already installed. ("upgrade", "upgrade") is deep upgrade, etc.

In this PR I implement this as options for new `install.install_by_name` function used by `install` command and for `deps.satisfy_dependencies`. There are no significant visible behavior changes. On [upgrade-install](https://github.com/mpeterv/luarocks/tree/upgrade-install) branch of my fork I've implemented command-line flags `--upgrade`, `--lazy`, `--upgrade-deps` and `reinstall-deps` for testing.

This is work in progress but any feedback and reviews are welcome. I hope that even a half-broken (well, it sorta works) half-implementation (but see the other branch above) will bring `luarocks upgrade` or something equivalent closer to reality =D

One major issue is that when recursively upgrading or reinstalling dependencies shared dependencies are processed several times. It can be fixed by adding a blacklist argument to `deps.satisfy_dependencies`, but it may be worth it to rewrite it to build closure of all dependencies before installing anything at all.