### PR TITLE
Update repo URLs to luarocks.org instead of rocks.moonscript.org

### DIFF
--- a/test/testing.bat
+++ b/test/testing.bat
@@ -1,7 +1,7 @@
 @echo off
 Setlocal EnableDelayedExpansion EnableExtensions
 
-if not defined LUAROCKS_REPO set LUAROCKS_REPO=http://rocks.moonscript.org
+if not defined LUAROCKS_REPO set LUAROCKS_REPO=https://luarocks.org
 
 appveyor DownloadFile %LUAROCKS_REPO%/stdlib-41.0.0-1.src.rock
 luarocks build stdlib

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -225,7 +225,7 @@ luarocks_admin_nocov="run_lua --nocov luarocks-admin"
 mkdir -p "$testing_server"
 (
    cd "$testing_server"
-   luarocks_repo="http://rocks.moonscript.org"
+   luarocks_repo="https://luarocks.org"
    get() { [ -e `basename "$1"` ] || wget -c "$1"; }
    get "$luarocks_repo/luacov-${verrev_luacov}.src.rock"
    get "$luarocks_repo/luacov-${verrev_luacov}.rockspec"


### PR DESCRIPTION
Previously, this used an old URL and downloaded over HTTP, in cleartext. This commit updates to the URL that the old one redirects to, and changes to HTTPS encryption for security. HTTPS is currently impossible on rocks.moonscript.org because the security certificate for that domain expired in May 2015.

See posts on the lua-l mailing list tonight (not yet visible in the lua-l archives) for more context.