### PR TITLE
Make new_version work with scm rockspecs

### DIFF
--- a/src/luarocks/new_version.lua
+++ b/src/luarocks/new_version.lua
@@ -77,9 +77,6 @@ local function update_source_section(out_rs, out_name, url, old_ver, new_ver)
    if new_ver == old_ver then
       return true
    end
-   if not out_rs.source then
-      return nil, "'source' table is missing. Invalid rockspec?"
-   end
    if out_rs.source.dir then
       try_replace(out_rs.source, "dir", old_ver, new_ver)
    end

--- a/src/luarocks/new_version.lua
+++ b/src/luarocks/new_version.lua
@@ -107,7 +107,7 @@ end
 function new_version.run(...)
    local flags, input, version, url = util.parse_flags(...)
    if not input then
-      return nil, "Missing arguments: expected program or rockspec. "..util.see_help("new_version")
+      return nil, "Missing argument: expected package or rockspec. "..util.see_help("new_version")
    end
    assert(type(input) == "string")
    

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -427,6 +427,7 @@ fail_make_which_rockspec() { rm -rf ./luasocket-${verrev_luasocket} && $luarocks
 
 test_new_version() { $luarocks download --rockspec luacov ${version_luacov} &&  $luarocks new_version ./luacov-${version_luacov}-1.rockspec 0.2 && rm ./luacov-0.*; }
 test_new_version_url() { $luarocks download --rockspec abelhas 1.0 && $luarocks new_version ./abelhas-1.0-1.rockspec 1.1 https://github.com/downloads/ittner/abelhas/abelhas-1.1.tar.gz && rm ./abelhas-*; }
+test_new_version_tag() { $luarocks download --rockspec luacov ${version_luacov} && $luarocks new_version ./luacov-${version_luacov}-1.rockspec --tag v0.3 && rm ./luacov-0.3-1.rockspec; }
 
 test_pack() { $luarocks list && $luarocks pack luacov && rm ./luacov-*.rock; }
 test_pack_src() { $luarocks install $luasec && $luarocks download --rockspec luasocket && $luarocks pack ./luasocket-${verrev_luasocket}.rockspec && rm ./luasocket-${version_luasocket}-*.rock; }


### PR DESCRIPTION
I'd like to have a single scm rockspec in my repo and make rockspecs for releases by adding source.tag field. `luarocks new_version`, given an scm rockspec and a version, currently prints

```
Warning: invalid URL - Error fetching file: Unsupported protocol git+https
Warning: URL is the same, but MD5 has changed. Old rockspec is broken.
```

and produces a rockspec without source.tag.

This PR fixes some behaviour issues in MD5 checking (it is currently checked even if the old rockspec doesn't have source.md5 field or if source archive fetching failed). For the scm rockspec usecase, it adds --tag flag that sets source.tag field in the new rockspec. It's also used to infer new version if it's not given. Common convention `tag == 'v' .. version` is supported. So, now I can run `luarocks new-rockspec myrock-scm-1.rockspec --tag 0.2.0` to create a rockspec for 0.2.0 release.