### PR TITLE
Show dependency constraints in `luarocks show`

### DIFF
--- a/src/luarocks/show.lua
+++ b/src/luarocks/show.lua
@@ -28,7 +28,9 @@ With these flags, return only the desired information:
 ]]
 
 local function keys_as_string(t, sep)
-    return table.concat(util.keys(t), sep or " ")
+   local keys = util.keys(t)
+   table.sort(keys)
+   return table.concat(keys, sep or " ")
 end
 
 local function word_wrap(line) 


### PR DESCRIPTION
Currently in "dependencies" section `luarocks show` prints names of all dependencies of the rock, including "deep" dependencies. I suggest that it should only list direct dependencies (using list from rockspec), and that version constraints should be printed, too. E.g. for sailor instead of

```
Depends on:
	lua_cliargs
	xavante
	lua-term
	coxpcall
	busted
	luafilesystem
	rings
	penlight
	datafile
	dkjson
	mediator_lua
	luassert
	lbase64
	wsapi
	wsapi-xavante
	luasocket
	copas
	valua
	say
```

print

```
Depends on:
	lua >= 5.1, < 5.3
	datafile >= 0.1
	luafilesystem >= 1.6.2
	valua >= 0.2.2
	lbase64 >= 2012080
	cgilua >= 5.1.4
	xavante >= 2.3
	wsapi-xavante >= 1.6.1
	busted >= 2.0.rc9
```