### PR TITLE
Use mkstemp()/mkdtemp() where available

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -362,6 +362,7 @@ local defaults = {
       FIND = "find",
       TEST = "test",
       CHMOD = "chmod",
+      MKTEMP = "mktemp",
 
       ZIP = "zip",
       UNZIP = "unzip -n",

--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -28,8 +28,6 @@ local patch = require("luarocks.tools.patch")
 
 local dir_stack = {}
 
-math.randomseed(os.time())
-
 local dir_separator = "/"
 
 --- Quote argument for shell processing.
@@ -65,23 +63,6 @@ function fs_lua.is_writable(file)
       if fh then fh:close() end
    end
    return result
-end
-
---- Create a temporary directory.
--- @param name string: name pattern to use for avoiding conflicts
--- when creating temporary directory.
--- @return string or (nil, string): name of temporary directory or (nil, error message) on failure.
-function fs_lua.make_temp_dir(name)
-   assert(type(name) == "string")
-   name = dir.normalize(name)
-
-   local temp_dir = (os.getenv("TMP") or "/tmp") .. "/luarocks_" .. name:gsub(dir.separator, "_") .. "-" .. tostring(math.floor(math.random() * 10000))
-   local ok, err = fs.make_dir(temp_dir)
-   if ok then
-      return temp_dir
-   else
-      return nil, err
-   end
 end
 
 local function quote_args(command, ...)
@@ -783,6 +764,23 @@ end
 
 function fs_lua.get_permissions(file)
    return posix.stat(file, "mode")
+end
+
+--- Create a temporary directory.
+-- @param name string: name pattern to use for avoiding conflicts
+-- when creating temporary directory.
+-- @return string or (nil, string): name of temporary directory or (nil, error message) on failure.
+function fs_lua.make_temp_dir(name)
+   assert(type(name) == "string")
+   name = dir.normalize(name)
+
+   local template = (os.getenv("TMPDIR") or "/tmp") .. "/luarocks_" .. name:gsub(dir.separator, "_") .. "-XXXXXX"
+   local temp_dir, err = posix.mkdtemp(template)
+   if temp_dir then
+      return temp_dir
+   else
+      return nil, err
+   end
 end
 
 end

--- a/src/luarocks/fs/unix.lua
+++ b/src/luarocks/fs/unix.lua
@@ -9,8 +9,6 @@ local cfg = require("luarocks.cfg")
 local dir = require("luarocks.dir")
 local util = require("luarocks.util")
 
-math.randomseed(os.time())
-
 --- Annotate command string for quiet execution.
 -- @param cmd string: A command-line string.
 -- @return string: The command-line, with silencing annotation.

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -351,4 +351,22 @@ function tools.set_time(file, time)
    return fs.execute(vars.TOUCH, "-d", "@"..tostring(time), file)
 end
 
+--- Create a temporary directory.
+-- @param name string: name pattern to use for avoiding conflicts
+-- when creating temporary directory.
+-- @return string or (nil, string): name of temporary directory or (nil, error message) on failure.
+function tools.make_temp_dir(name)
+   assert(type(name) == "string")
+   name = dir.normalize(name)
+
+   local template = (os.getenv("TMPDIR") or "/tmp") .. "/luarocks_" .. name:gsub(dir.separator, "_") .. "-XXXXXX"
+   local pipe = io.popen(vars.MKTEMP.." -d "..fs.Q(template))
+   local dirname = pipe:read("*l")
+   pipe:close()
+   if dirname and dirname:match("^/") then
+      return dirname
+   end
+   return nil, "Failed to create temporary directory "..tostring(dirname)
+end
+
 return tools

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -10,6 +10,8 @@ local cfg = require("luarocks.cfg")
 local dir = require("luarocks.dir")
 local util = require("luarocks.util")
 
+math.randomseed(os.time())
+
 -- Monkey patch io.popen and os.execute to make sure quoting
 -- works as expected.
 -- See http://lua-users.org/lists/lua-l/2013-11/msg00367.html
@@ -219,6 +221,23 @@ function win32.is_writable(file)
       if fh then fh:close() end
    end
    return result
+end
+
+--- Create a temporary directory.
+-- @param name string: name pattern to use for avoiding conflicts
+-- when creating temporary directory.
+-- @return string or (nil, string): name of temporary directory or (nil, error message) on failure.
+function win32.make_temp_dir(name)
+   assert(type(name) == "string")
+   name = dir.normalize(name)
+
+   local temp_dir = os.getenv("TMP") .. "/luarocks_" .. name:gsub(dir.separator, "_") .. "-" .. tostring(math.floor(math.random() * 10000))
+   local ok, err = fs.make_dir(temp_dir)
+   if ok then
+      return temp_dir
+   else
+      return nil, err
+   end
 end
 
 function win32.tmpname()


### PR DESCRIPTION
This PR makes luarocks

* Use mkdtemp() to create temporary directories on unix platforms
* Respect $TMPDIR in environments where it has been set

as suggested by <http://0pointer.net/blog/projects/tmp.html>

Relevant snippet:

> Usually it is recommended to use $TMPDIR if it is set before falling back to /tmp directly. As mentioned, this is a tmpfs on many Linuxes/Unixes (and most likely will be for most soon), and hence should be used only for small files. It's generally a shared namespace, hence the only APIs for using it should be mkstemp(), mkdtemp() (and friends) to be entirely safe

When luaposix is installed, they will be called directly, otherwise the shell [mktemp](http://linux.die.net/man/1/mktemp) will be used instead.

Not tested on MacOS/BSD.
