### PR TITLE
Implement MSYS2 support

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -113,6 +113,10 @@ elseif system == "SunOS" then
 elseif system and system:match("^CYGWIN") then
    cfg.platforms.unix = true
    cfg.platforms.cygwin = true
+elseif system and system:match("^MSYS") then
+   cfg.platforms.unix = true
+   cfg.platforms.msys = true
+   cfg.platforms.cygwin = true
 elseif system and system:match("^Windows") then
    cfg.platforms.windows = true
    cfg.platforms.win32 = true
@@ -137,10 +141,11 @@ local platform_order = {
    linux = 7,
    macosx = 8,
    cygwin = 9,
+   msys = 10,
    -- Windows
-   win32 = 10,
-   mingw32 = 11,
-   windows = 12 }
+   win32 = 11,
+   mingw32 = 12,
+   windows = 13 }
 
 
 -- Path configuration:
@@ -517,6 +522,23 @@ if cfg.platforms.cygwin then
    defaults.variables.LD = "echo -llua | xargs gcc"
    defaults.variables.LIBFLAG = "-shared"
 end
+
+if cfg.platforms.msys then
+   -- msys is basically cygwin made out of mingw, meaning the subsytem is unixish
+   -- enough, yet we can freely mix with native win32
+   defaults.external_deps_patterns = {
+      bin = { "?.exe", "?.bat", "?" },
+      lib = { "lib?.so", "lib?.so.*", "lib?.dll.a", "?.dll.a",
+              "lib?.a", "lib?.dll", "?.dll", "?.lib" },
+      include = { "?.h" }
+   }
+   defaults.runtime_external_deps_patterns = {
+      bin = { "?.exe", "?.bat" },
+      lib = { "lib?.so", "?.dll", "lib?.dll" },
+      include = { "?.h" }
+   }
+end
+
 
 if cfg.platforms.bsd then
    defaults.variables.MAKE = "gmake"


### PR DESCRIPTION
This does what it says. Small tutorial for people using MSYS2 environment:

1. Get lua 5.1 source from lua.org
2. make linux && make install
3. get luarocks
4. ./configure
5. make build
6. make install

Do NOT use MSYS2 mingw64-* labeled repositories, lua in there is broken beyond repair (mingw64- repos lack the unix abstraction layer, so things like io.popen are sketchy).

Put export PATH=$PATH:/usr/local/bin and  \`luarocks path | sed -e "s/'//g"\` into your /etc/bash.bashrc and you should be good to go. I tested this only with Win10, Lua 5.1, MSYS2 x64. Feedback from other setups would be welcome.

Note that running LuaJIT like this is a bit trickier, though you might have some success on 32bit MSYS (cd src; make HOST_SYS=CYGWIN)