### PR TITLE
Add support for the --tree argument to the path command

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -666,17 +666,23 @@ function cfg.make_paths_from_tree(tree)
    return lua_path, lib_path, bin_path
 end
 
-function cfg.package_paths()
+function cfg.package_paths(current)
    local new_path, new_cpath, new_bin = {}, {}, {}
-   for _,tree in ipairs(cfg.rocks_trees) do
+   local function add_tree_to_paths(tree)
       local lua_path, lib_path, bin_path = cfg.make_paths_from_tree(tree)
       table.insert(new_path, lua_path.."/?.lua")
       table.insert(new_path, lua_path.."/?/init.lua")
       table.insert(new_cpath, lib_path.."/?."..cfg.lib_extension)
       table.insert(new_bin, bin_path)
    end
+   if current then
+      add_tree_to_paths(current)
+   end
+   for _,tree in ipairs(cfg.rocks_trees) do
+      add_tree_to_paths(tree)
+   end
    if extra_luarocks_module_dir then
-     table.insert(new_path, extra_luarocks_module_dir)
+      table.insert(new_path, extra_luarocks_module_dir)
    end
    return table.concat(new_path, ";"), table.concat(new_cpath, ";"), table.concat(new_bin, cfg.export_path_separator)
 end

--- a/src/luarocks/path_cmd.lua
+++ b/src/luarocks/path_cmd.lua
@@ -37,7 +37,7 @@ function path_cmd.run(...)
    local flags = util.parse_flags(...)
    local deps_mode = deps.get_deps_mode(flags)
    
-   local lr_path, lr_cpath, lr_bin = cfg.package_paths()
+   local lr_path, lr_cpath, lr_bin = cfg.package_paths(flags["tree"])
    local path_sep = cfg.export_path_separator
 
    if flags["lr-path"] then

--- a/test/testing.lua
+++ b/test/testing.lua
@@ -266,6 +266,7 @@ local tests = {
    test_path_lr_path = function() return run "$luarocks path --lr-path" end,
    test_path_lr_cpath = function() return run "$luarocks path --lr-cpath" end,
    test_path_lr_bin = function() return run "$luarocks path --lr-bin" end,
+   test_path_with_tree = function() return run "$luarocks path --tree=lua_modules" end,
    fail_purge_missing_tree = function() return run '$luarocks purge --tree="$testing_tree"' end,
    test_purge = function() return run '$luarocks purge --tree="$testing_sys_tree"' end,
    test_remove = function()

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -449,6 +449,7 @@ test_path() { $luarocks path --bin; }
 test_path_lr_path() { $luarocks path --lr-path; }
 test_path_lr_cpath() { $luarocks path --lr-cpath; }
 test_path_lr_bin() { $luarocks path --lr-bin; }
+test_path_with_tree() { $luarocks path --tree=lua_modules; }
 
 fail_purge_missing_tree() { $luarocks purge --tree="$testing_tree"; }
 fail_purge_tree_notstring() { $luarocks purge --tree=1; }


### PR DESCRIPTION
I was trying to cobble together a solution for project-local dependency installations using `--tree` and wanted to add these to all of the appropriate paths, but found that `luarocks path` does not respect the `--tree` argument.

This adds support for the `--tree` argument in a way that is hopefully not too stupid. Any feedback is very much appreciated.