### PR TITLE
Change output and order of deps installation

### DIFF
--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -332,15 +332,7 @@ function build.build_rockspec(rockspec_file, need_to_fetch, minimal_mode, deps_m
    ok, err = manif.update_manifest(name, version, nil, deps_mode)
    if err then return nil, err end
 
-   local license = ""
-   if rockspec.description and rockspec.description.license then
-      license = ("(license: "..rockspec.description.license..")")
-   end
-
-   local root_dir = path.root_dir(cfg.rocks_dir)
-   util.printout(name.." "..version.." is now built and installed in "..root_dir.." "..license)
-   util.printout()
-   
+   util.announce_install(rockspec)
    util.remove_scheduled_function(rollback)
    return name, version
 end

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -488,6 +488,7 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
             if not url then
                return nil, "Could not satisfy dependency "..deps.show_dep(dep)..": "..err
             end
+            util.printout("Installing "..url)
             local ok, err, errcode = install.run(url, deps.deps_mode_to_flag(deps_mode))
             if not ok then
                return nil, "Failed installing dependency: "..url.." - "..err, errcode

--- a/src/luarocks/deps.lua
+++ b/src/luarocks/deps.lua
@@ -449,53 +449,43 @@ function deps.fulfill_dependencies(rockspec, deps_mode)
       end
    end
 
-   local _, missing, no_upgrade = deps.match_deps(rockspec, nil, deps_mode)
+   local first_missing_dep = true
 
-   if next(no_upgrade) then
-      util.printerr("Missing dependencies for "..rockspec.name.." "..rockspec.version..":")
-      for _, dep in pairs(no_upgrade) do
-         util.printerr(deps.show_dep(dep))
-      end
-      if next(missing) then
-         for _, dep in pairs(missing) do
-            util.printerr(deps.show_dep(dep))
+   for _, dep in ipairs(rockspec.dependencies) do
+      if not match_dep(dep, nil, deps_mode) then
+         if first_missing_dep then
+            util.printout()
+            first_missing_dep = false
          end
-      end
-      util.printerr()
-      for _, dep in pairs(no_upgrade) do
-         util.printerr("This version of "..rockspec.name.." is designed for use with")
-         util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
-         util.printerr("automatically. Please upgrade "..dep.name.." with")
-         util.printerr("   luarocks install "..dep.name)
-         util.printerr("or choose an older version of "..rockspec.name.." with")
-         util.printerr("   luarocks search "..rockspec.name)
-      end
-      return nil, "Failed matching dependencies."
-   end
 
-   if next(missing) then
-      util.printerr()
-      util.printerr("Missing dependencies for "..rockspec.name..":")
-      for _, dep in pairs(missing) do
-         util.printerr(deps.show_dep(dep))
-      end
-      util.printerr()
+         local any_installed = match_dep(search.make_query(dep.name), nil, deps_mode)
+         local installation_type = cfg.rocks_provided[dep.name] and "provided by VM" or "installed"
+         local status = any_installed and any_installed.version.." "..installation_type or "missing"
+         util.printout(("%s %s depends on %s (%s)"):format(
+            rockspec.name, rockspec.version, deps.show_dep(dep), status))
 
-      for _, dep in pairs(missing) do
-         -- Double-check in case dependency was filled during recursion.
-         if not match_dep(dep, nil, deps_mode) then
-            local url, err = search.find_suitable_rock(dep)
-            if not url then
-               return nil, "Could not satisfy dependency "..deps.show_dep(dep)..": "..err
-            end
-            util.printout("Installing "..url)
-            local ok, err, errcode = install.run(url, deps.deps_mode_to_flag(deps_mode))
-            if not ok then
-               return nil, "Failed installing dependency: "..url.." - "..err, errcode
-            end
+         if dep.constraints[1] and dep.constraints[1].no_upgrade then
+            util.printerr("This version of "..rockspec.name.." is designed for use with")
+            util.printerr(deps.show_dep(dep)..", but is configured to avoid upgrading it")
+            util.printerr("automatically. Please upgrade "..dep.name.." with")
+            util.printerr("   luarocks install "..dep.name)
+            util.printerr("or choose an older version of "..rockspec.name.." with")
+            util.printerr("   luarocks search "..rockspec.name)
+            return nil, "Failed matching dependencies"
+         end
+
+         local url, search_err = search.find_suitable_rock(dep)
+         if not url then
+            return nil, "Could not satisfy dependency "..deps.show_dep(dep)..": "..search_err
+         end
+         util.printout("Installing "..url)
+         local ok, install_err, errcode = install.run(url, deps.deps_mode_to_flag(deps_mode))
+         if not ok then
+            return nil, "Failed installing dependency: "..url.." - "..install_err, errcode
          end
       end
    end
+
    return true
 end
 

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -168,7 +168,6 @@ function install.run(...)
    if not ok then return nil, err, cfg.errorcodes.PERMISSIONDENIED end
 
    if name:match("%.rockspec$") or name:match("%.src%.rock$") then
-      util.printout("Using "..name.."... switching to 'build' mode")
       local build = require("luarocks.build")
       return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode", "only-deps"))
    elseif name:match("%.rock$") then
@@ -190,7 +189,7 @@ function install.run(...)
       if not url then
          return nil, err
       end
-      util.printout("Installing "..url.."...")
+      util.printout("Installing "..url)
       return install.run(url, util.forward_flags(flags))
    end
 end

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -98,15 +98,7 @@ function install.install_binary_rock(rock_file, deps_mode)
    ok, err = manif.update_manifest(name, version, nil, deps_mode)
    if err then return nil, err end
    
-   local license = ""
-   if rockspec.description.license then
-      license = ("(license: "..rockspec.description.license..")")
-   end
-
-   local root_dir = path.root_dir(cfg.rocks_dir)
-   util.printout()
-   util.printout(name.." "..version.." is now installed in "..root_dir.." "..license)
-   
+   util.announce_install(rockspec)
    util.remove_scheduled_function(rollback)
    return name, version
 end

--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -432,8 +432,6 @@ function manif.update_manifest(name, version, repo, deps_mode)
    
    if deps_mode == "none" then deps_mode = cfg.deps_mode end
 
-   util.printout("Updating manifest for "..repo)
-
    local manifest, err = manif.load_manifest(repo)
    if not manifest then
       util.printerr("No existing manifest. Attempting to rebuild...")

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -505,6 +505,20 @@ function util.see_help(command, program)
    return "See '"..util.this_program(program or "luarocks")..' help'..(command and " "..command or "").."'."
 end
 
+function util.announce_install(rockspec)
+   local cfg = require("luarocks.cfg")
+   local path = require("luarocks.path")
+
+   local suffix = ""
+   if rockspec.description and rockspec.description.license then
+      suffix = " (license: "..rockspec.description.license..")"
+   end
+
+   local root_dir = path.root_dir(cfg.rocks_dir)
+   util.printout(rockspec.name.." "..rockspec.version.." is now installed in "..root_dir..suffix)
+   util.printout()
+end
+
 -- from http://lua-users.org/wiki/SplitJoin
 -- by PhilippeLhoste
 function util.split_string(str, delim, maxNb)


### PR DESCRIPTION
This PR makes output for `luarocks install` and other commands that satisfy dependencies closer to what #496 does:

* Process dependencies in the order of `rockspec.dependencies` array.
* Announce each missing dependency just before installing it, instead of listing them all beforehand (makes it easier to understand why each rock is installed in a long list).
* Show what versions are already installed for missing dependencies.
* Remove not very useful (IMO) lines like `switching to build mode` and `updating manifest`.

See comparison of outputs of `luarocks install sailor`: https://gist.github.com/mpeterv/a43fbcdeadaec40dd6fa3284ea7f07dd

In a nutshell:

```
Using https://luarocks.org/valua-0.3-1.src.rock... switching to 'build' mode
Updating manifest for /home/mpeterv/luarocks/here/lib/luarocks/rocks
valua 0.3-1 is now built and installed in /home/mpeterv/luarocks/here (license: MIT)
```

changes to

```
sailor 0.5-4 depends on valua >= 0.2.2 (missing)
Installing https://luarocks.org/valua-0.3-1.src.rock
valua 0.3-1 is now installed in /home/mpeterv/luarocks/here (license: MIT)
```