### PR TITLE
Allow passing --force to `luarocks install` in all cases

### DIFF
--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -170,7 +170,7 @@ function install.run(...)
    if name:match("%.rockspec$") or name:match("%.src%.rock$") then
       util.printout("Using "..name.."... switching to 'build' mode")
       local build = require("luarocks.build")
-      return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode", "only-deps"))
+      return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode", "only-deps", "force", "force-fast"))
    elseif name:match("%.rock$") then
       if flags["only-deps"] then
          ok, err = install.install_binary_rock_deps(name, deps.get_deps_mode(flags))


### PR DESCRIPTION
When installing an old version of a rock that breaks existing
dependencies, removing previously installed version fails,
and --force is suggested. However, when installing using a rockspec
or a source rock --force is not forwarded to build command.

This really needs a test, plus a test to verify failure without `--force`, but that would require pulling in some new rocks: those currently fetched don't use sufficiently strict dependency constraints.