### PR TITLE
Don't put array items on the same line when persisting

### DIFF
--- a/src/luarocks/persist.lua
+++ b/src/luarocks/persist.lua
@@ -147,7 +147,7 @@ write_table = function(out, tbl, level, field_order)
       end
 
       write_value(out, v, level, sub_order)
-      if type(k) == "number" then
+      if type(v) == "number" then
          sep = ", "
          indent = false
       else


### PR DESCRIPTION
Rockspec fields with array values (e.g. dependencies) are typically written with each item on its own line. This change makes `luarocks new-version` follow this style, too. This also affects they way manifests are saved.