### PR TITLE
Infer name and version for `luarocks write-rockspec` without args

### DIFF
--- a/src/luarocks/write_rockspec.lua
+++ b/src/luarocks/write_rockspec.lua
@@ -12,14 +12,16 @@ local type_check = require("luarocks.type_check")
 local util = require("luarocks.util")
 
 write_rockspec.help_summary = "Write a template for a rockspec file."
-write_rockspec.help_arguments = "[--output=<file> ...] [<name>] [<version>] {<url>|<path>}"
+write_rockspec.help_arguments = "[--output=<file> ...] [<name>] [<version>] [<url>|<path>]"
 write_rockspec.help = [[
 This command writes an initial version of a rockspec file,
-based on an URL or a local path. You may use a relative path such as '.'.
-If a local path is given, name and version arguments are mandatory.
-For URLs, LuaRocks will attempt to infer name and version if not given.
-
-If a repository URL is given with no version, it creates an 'scm' rock.
+based on a name, a version, and a location (an URL or a local path).
+If only two arguments are given, the first one is considered the name and the
+second one is the location.
+If only one argument is given, it must be the location.
+If no arguments are given, current directory is used as location.
+LuaRocks will attempt to infer name and version if not given,
+using 'scm' as default version.
 
 Note that the generated file is a _starting point_ for writing a
 rockspec, and is not guaranteed to be complete or correct.
@@ -198,19 +200,17 @@ end
 
 function write_rockspec.run(...)
    local flags, name, version, url_or_dir = util.parse_flags(...)
-   
-   if not name then
-      return nil, "Missing arguments. "..util.see_help("write_rockspec")
-   end
 
-   if name and not version then
+   if not name then
+      url_or_dir = "."
+   elseif not version then
       url_or_dir = name
       name = nil
    elseif not url_or_dir then
       url_or_dir = version
       version = nil
    end
-   
+
    if flags["tag"] then
       if not version then
          version = flags["tag"]:gsub("^v", "")
@@ -218,28 +218,25 @@ function write_rockspec.run(...)
    end
 
    local protocol, pathname = dir.split_url(url_or_dir)
-   if not fetch.is_basic_protocol(protocol) then
-      if not name then
-         name = dir.base_name(url_or_dir):gsub("%.[^.]+$", "")
+   if protocol == "file" then
+      if pathname == "." then
+         name = name or dir.base_name(fs.current_dir())
       end
-      if not version then
-         version = "scm"
-      end
-   elseif protocol ~= "file" then
+   elseif fetch.is_basic_protocol(protocol) then
       local filename = dir.base_name(url_or_dir)
       local newname, newversion = filename:match("(.*)-([^-]+)")
-      if (not name) and newname then
-         name = newname
+      if newname then
+         name = name or newname
+         version = version or newversion:gsub("%.[a-z]+$", ""):gsub("%.tar$", "")
       end
-      if (not version) and newversion then
-         version = newversion:gsub(".[a-z]+$", ""):gsub(".tar$", "")
-      end
-      if not (name and version) then
-         return nil, "Missing name and version arguments. "..util.see_help("write_rockspec")
-      end
-   elseif not version then
-      return nil, "Missing name and version arguments. "..util.see_help("write_rockspec")
+   else
+      name = name or dir.base_name(url_or_dir):gsub("%.[^.]+$", "")
    end
+
+   if not name then
+      return nil, "Could not infer rock name. "..util.see_help("write_rockspec")
+   end
+   version = version or "scm"
 
    local filename = flags["output"] or dir.path(fs.current_dir(), name:lower().."-"..version.."-1.rockspec")
    

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -364,7 +364,6 @@ fail_upload_noarg() { $luarocks upload; }
 fail_remove_noarg() { $luarocks remove; }
 fail_doc_noarg() { $luarocks doc; }
 fail_new_version_noarg() { $luarocks new_version; }
-fail_write_rockspec_noarg() { $luarocks write_rockspec; }
 
 fail_build_invalid() { $luarocks build invalid; }
 fail_download_invalid() { $luarocks download invalid; }
@@ -523,6 +522,9 @@ test_deps_mode_make_order() { $luarocks build --tree="$testing_sys_tree" lpeg &&
 test_deps_mode_make_order_sys() { $luarocks build --tree="$testing_tree" lpeg && rm -rf ./lxsh-${verrev_lxsh} && $luarocks download --source lxsh ${verrev_lxsh} && $luarocks unpack ./lxsh-${verrev_lxsh}.src.rock && cd lxsh-${verrev_lxsh}/lxsh-${version_lxsh}-1  && $luarocks make --tree="$testing_sys_tree" --deps-mode=order && cd ../.. && [ `$luarocks_noecho list --tree="$testing_tree" --porcelain lpeg | wc -l` = 1 ] && rm -rf ./lxsh-${verrev_lxsh}; }
 
 test_write_rockspec() { $luarocks write_rockspec git://github.com/keplerproject/luarocks; }
+test_write_rockspec_name() { $luarocks write_rockspec luarocks git://github.com/keplerproject/luarocks; }
+test_write_rockspec_name_version() { $luarocks write_rockspec luarocks 7.8.9 git://github.com/keplerproject/luarocks; }
+test_write_rockspec_current_dir() { $luarocks write_rockspec; }
 test_write_rockspec_tag() { $luarocks write_rockspec git://github.com/keplerproject/luarocks --tag=v2.3.0; }
 test_write_rockspec_lib() { $luarocks write_rockspec git://github.com/mbalmer/luafcgi --lib=fcgi --license="3-clause BSD" --lua-version=5.1,5.2; }
 test_write_rockspec_format() { $luarocks write_rockspec git://github.com/keplerproject/luarocks --rockspec-format=1.1 --lua-version=5.1,5.2; }


### PR DESCRIPTION
* Default path for `write-rockspec` is now `.`.
* Use `scm` as default version in all cases.
* Infer rock name as base directory of current path when passing `.` as path.

As a result, `luarocks write-rockspec` with no arguments creates an scm rockspec. It's quite nice for version control based rocks. Rock name is inferred from current directory as the last path component. Would be nice to be able to do this for arbitrary paths but there is no utility function for collapsing paths containing `..` and `.`.