### PR TITLE
luarocks new-version: make rockspec argument optional

### DIFF
--- a/src/luarocks/make.lua
+++ b/src/luarocks/make.lua
@@ -49,33 +49,6 @@ To install rocks, you'll normally want to use the "install" and
 
 ]]
 
---- Collect rockspecs located in a subdirectory.
--- @param versions table: A table mapping rock names to newest rockspec versions.
--- @param paths table: A table mapping rock names to newest rockspec paths.
--- @param unnamed_paths table: An array of rockspec paths that don't contain rock
--- name and version in regular format.
--- @param subdir string: path to subdirectory.
-local function collect_rockspecs(versions, paths, unnamed_paths, subdir)
-   if fs.is_dir(subdir) then
-      for file in fs.dir(subdir) do
-         file = dir.path(subdir, file)
-
-         if file:match("rockspec$") and fs.is_file(file) then
-            local rock, version = path.parse_name(file)
-
-            if rock then
-               if not versions[rock] or deps.compare_versions(version, versions[rock]) then
-                  versions[rock] = version
-                  paths[rock] = file
-               end
-            else
-               table.insert(unnamed_paths, file)
-            end
-         end
-      end
-   end
-end
-
 --- Driver function for "make" command.
 -- @param name string: A local rockspec.
 -- @return boolean or (nil, string, exitcode): True if build was successful; nil and an
@@ -85,34 +58,10 @@ function make.run(...)
    assert(type(rockspec) == "string" or not rockspec)
    
    if not rockspec then
-      -- Try to infer default rockspec name.
-      local versions, paths, unnamed_paths = {}, {}, {}
-      -- Look for rockspecs in some common locations.
-      collect_rockspecs(versions, paths, unnamed_paths, ".")
-      collect_rockspecs(versions, paths, unnamed_paths, "rockspec")
-      collect_rockspecs(versions, paths, unnamed_paths, "rockspecs")
-
-      if #unnamed_paths > 0 then
-         -- There are rockspecs not following "name-version.rockspec" format.
-         -- More than one are ambiguous.
-         if #unnamed_paths > 1 then
-            return nil, "Please specify which rockspec file to use."
-         else
-            rockspec = unnamed_paths[1]
-         end
-      else
-         local rock = next(versions)
-
-         if rock then
-            -- If there are rockspecs for multiple rocks it's ambiguous.
-            if next(versions, rock) then
-               return nil, "Please specify which rockspec file to use."
-            else
-               rockspec = paths[rock]
-            end
-         else
-            return nil, "Argument missing: please specify a rockspec to use on current directory."
-         end
+      local err
+      rockspec, err = util.get_default_rockspec()
+      if not rockspec then
+         return nil, err
       end
    end
    if not rockspec:match("rockspec$") then

--- a/test/testing.sh
+++ b/test/testing.sh
@@ -363,7 +363,6 @@ fail_unpack_noarg() { $luarocks unpack; }
 fail_upload_noarg() { $luarocks upload; }
 fail_remove_noarg() { $luarocks remove; }
 fail_doc_noarg() { $luarocks doc; }
-fail_new_version_noarg() { $luarocks new_version; }
 
 fail_build_invalid() { $luarocks build invalid; }
 fail_download_invalid() { $luarocks download invalid; }
@@ -446,6 +445,7 @@ test_make_pack_binary_rock() { rm -rf ./lxsh-${verrev_lxsh} &&  $luarocks downlo
 test_new_version() { $luarocks download --rockspec luacov ${version_luacov} &&  $luarocks new_version ./luacov-${version_luacov}-1.rockspec 0.2 && rm ./luacov-0.*; }
 test_new_version_url() { $luarocks download --rockspec abelhas 1.0 && $luarocks new_version ./abelhas-1.0-1.rockspec 1.1 https://github.com/downloads/ittner/abelhas/abelhas-1.1.tar.gz && rm ./abelhas-*; }
 test_new_version_tag() { $luarocks download --rockspec luacov ${version_luacov} && $luarocks new_version ./luacov-${version_luacov}-1.rockspec --tag v0.3 && rm ./luacov-0.3-1.rockspec; }
+test_new_version_tag_without_arg() { rm -rf ./*rockspec && $luarocks download --rockspec luacov ${version_luacov} && $luarocks new_version --tag v0.3 && rm ./luacov-0.3-1.rockspec; }
 
 test_pack() { $luarocks list && $luarocks pack luacov && rm ./luacov-*.rock; }
 test_pack_src() { $luarocks install $luasec && $luarocks download --rockspec luasocket && $luarocks pack ./luasocket-${verrev_luasocket}.rockspec && rm ./luasocket-${version_luasocket}-*.rock; }


### PR DESCRIPTION
Like with `make`, it makes sense for `new-version` to default to latest available rockspec, picked same way `make` does it.