### PR TITLE
Refactor cli to avoid double args parsing

### DIFF
--- a/src/luarocks/add.lua
+++ b/src/luarocks/add.lua
@@ -12,6 +12,7 @@ local index = require("luarocks.index")
 local fs = require("luarocks.fs")
 local cache = require("luarocks.cache")
 
+util.add_run_function(add)
 add.help_summary = "Add a rock or rockspec to a rocks server."
 add.help_arguments = "[--server=<server>] [--no-refresh] {<rockspec>|<rock>...}"
 add.help = [[
@@ -107,9 +108,8 @@ local function add_files_to_server(refresh, rockfiles, server, upload_server)
    return true
 end
 
-function add.run(...)
-   local files = { util.parse_flags(...) }
-   local flags = table.remove(files, 1)
+function add.command(flags, ...)
+   local files = {...}
    if #files < 1 then
       return nil, "Argument missing. "..util.see_help("add", "luarocks-admin")
    end

--- a/src/luarocks/admin_remove.lua
+++ b/src/luarocks/admin_remove.lua
@@ -12,6 +12,7 @@ local index = require("luarocks.index")
 local fs = require("luarocks.fs")
 local cache = require("luarocks.cache")
 
+util.add_run_function(admin_remove)
 admin_remove.help_summary = "Remove a rock or rockspec from a rocks server."
 admin_remove.help_arguments = "[--server=<server>] [--no-refresh] {<rockspec>|<rock>...}"
 admin_remove.help = [[
@@ -77,9 +78,8 @@ local function remove_files_from_server(refresh, rockfiles, server, upload_serve
    return true
 end
 
-function admin_remove.run(...)
-   local files = { util.parse_flags(...) }
-   local flags = table.remove(files, 1)
+function admin_remove.command(flags, ...)
+   local files = {...}
    if #files < 1 then
       return nil, "Argument missing. "..util.see_help("remove", "luarocks-admin")
    end

--- a/src/luarocks/build.lua
+++ b/src/luarocks/build.lua
@@ -16,6 +16,7 @@ local manif = require("luarocks.manif")
 local remove = require("luarocks.remove")
 local cfg = require("luarocks.cfg")
 
+util.add_run_function(build)
 build.help_summary = "Build/compile a rock."
 build.help_arguments = "[--pack-binary-rock] [--keep] {<rockspec>|<rock>|<name> [<version>]}"
 build.help = [[
@@ -390,8 +391,7 @@ end
 -- also be given.
 -- @return boolean or (nil, string, exitcode): True if build was successful; nil and an
 -- error message otherwise. exitcode is optionally returned.
-function build.run(...)
-   local flags, name, version = util.parse_flags(...)
+function build.command(flags, name, version)
    if type(name) ~= "string" then
       return nil, "Argument missing. "..util.see_help("build")
    end

--- a/src/luarocks/config_cmd.lua
+++ b/src/luarocks/config_cmd.lua
@@ -6,6 +6,7 @@ local cfg = require("luarocks.cfg")
 local util = require("luarocks.util")
 local dir = require("luarocks.dir")
 
+util.add_run_function(config_cmd)
 config_cmd.help_summary = "Query information about the LuaRocks configuration."
 config_cmd.help_arguments = "<flag>"
 config_cmd.help = [[
@@ -33,9 +34,7 @@ end
 
 --- Driver function for "config" command.
 -- @return boolean: True if succeeded, nil on errors.
-function config_cmd.run(...)
-   local flags = util.parse_flags(...)
-   
+function config_cmd.command(flags)
    if flags["lua-incdir"] then
       print(cfg.variables.LUA_INCDIR)
       return true

--- a/src/luarocks/doc.lua
+++ b/src/luarocks/doc.lua
@@ -12,6 +12,7 @@ local fetch = require("luarocks.fetch")
 local fs = require("luarocks.fs")
 local download = require("luarocks.download")
 
+util.add_run_function(doc)
 doc.help_summary = "Show documentation for an installed rock."
 
 doc.help = [[
@@ -57,8 +58,7 @@ end
 -- @param name or nil: an existing package name.
 -- @param version string or nil: a version may also be passed.
 -- @return boolean: True if succeeded, nil on errors.
-function doc.run(...)
-   local flags, name, version = util.parse_flags(...)
+function doc.command(flags, name, version)
    if not name then
       return nil, "Argument missing. "..util.see_help("doc")
    end

--- a/src/luarocks/download.lua
+++ b/src/luarocks/download.lua
@@ -12,6 +12,7 @@ local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
 local cfg = require("luarocks.cfg")
 
+util.add_run_function(download)
 download.help_summary = "Download a specific rock file from a rocks server."
 download.help_arguments = "[--all] [--arch=<arch> | --source | --rockspec] [<name> [<version>]]"
 
@@ -84,9 +85,7 @@ end
 -- version may also be passed.
 -- @return boolean or (nil, string): true if successful or nil followed
 -- by an error message.
-function download.run(...)
-   local flags, name, version = util.parse_flags(...)
-   
+function download.command(flags, name, version)
    assert(type(version) == "string" or not version)
    if type(name) ~= "string" and not flags["all"] then
       return nil, "Argument missing, see help."

--- a/src/luarocks/help.lua
+++ b/src/luarocks/help.lua
@@ -12,6 +12,7 @@ local dir = require("luarocks.dir")
 
 local program = util.this_program("luarocks")
 
+util.add_run_function(help)
 help.help_summary = "Help on commands. Type '"..program.." help <command>' for more."
 
 help.help_arguments = "[<command>]"
@@ -40,9 +41,7 @@ end
 -- given, help summaries for all commands are shown.
 -- @return boolean or (nil, string): true if there were no errors
 -- or nil and an error message if an invalid command was requested.
-function help.run(...)
-   local flags, command = util.parse_flags(...)
-
+function help.command(flags, command)
    if not command then
       local conf = cfg.which_config()
       print_banner()

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -160,7 +160,7 @@ function install.command(flags, name, version)
 
    if name:match("%.rockspec$") or name:match("%.src%.rock$") then
       local build = require("luarocks.build")
-      return build.run(name, util.forward_flags(flags, "local", "keep", "deps-mode", "only-deps", "force", "force-fast"))
+      return build.command(flags, name)
    elseif name:match("%.rock$") then
       if flags["only-deps"] then
          ok, err = install.install_binary_rock_deps(name, deps.get_deps_mode(flags))
@@ -181,7 +181,7 @@ function install.command(flags, name, version)
          return nil, err
       end
       util.printout("Installing "..url)
-      return install.run(url, util.forward_flags(flags))
+      return install.command(flags, url)
    end
 end
 

--- a/src/luarocks/install.lua
+++ b/src/luarocks/install.lua
@@ -13,6 +13,7 @@ local manif = require("luarocks.manif")
 local remove = require("luarocks.remove")
 local cfg = require("luarocks.cfg")
 
+util.add_run_function(install)
 install.help_summary = "Install a rock."
 
 install.help_arguments = "{<rock>|<name> [<version>]}"
@@ -149,8 +150,7 @@ end
 -- may also be given.
 -- @return boolean or (nil, string, exitcode): True if installation was
 -- successful, nil and an error message otherwise. exitcode is optionally returned.
-function install.run(...)
-   local flags, name, version = util.parse_flags(...)
+function install.command(flags, name, version)
    if type(name) ~= "string" then
       return nil, "Argument missing. "..util.see_help("install")
    end

--- a/src/luarocks/lint.lua
+++ b/src/luarocks/lint.lua
@@ -8,6 +8,7 @@ local util = require("luarocks.util")
 local download = require("luarocks.download")
 local fetch = require("luarocks.fetch")
 
+util.add_run_function(lint)
 lint.help_summary = "Check syntax of a rockspec."
 lint.help_arguments = "<rockspec>"
 lint.help = [[
@@ -17,9 +18,7 @@ It returns success or failure if the text of a rockspec is
 syntactically correct.
 ]]
 
-function lint.run(...)
-   local flags, input = util.parse_flags(...)
-   
+function lint.command(flags, input)
    if not input then
       return nil, "Argument missing. "..util.see_help("lint")
    end

--- a/src/luarocks/list.lua
+++ b/src/luarocks/list.lua
@@ -10,6 +10,7 @@ local cfg = require("luarocks.cfg")
 local util = require("luarocks.util")
 local path = require("luarocks.path")
 
+util.add_run_function(list)
 list.help_summary = "List currently installed rocks."
 list.help_arguments = "[--porcelain] <filter>"
 list.help = [[
@@ -69,8 +70,7 @@ end
 -- @param filter string or nil: A substring of a rock name to filter by.
 -- @param version string or nil: a version may also be passed.
 -- @return boolean: True if succeeded, nil on errors.
-function list.run(...)
-   local flags, filter, version = util.parse_flags(...)
+function list.command(flags, filter, version)
    local query = search.make_query(filter and filter:lower() or "", version)
    query.exact_name = false
    local trees = cfg.rocks_trees

--- a/src/luarocks/make.lua
+++ b/src/luarocks/make.lua
@@ -15,6 +15,7 @@ local pack = require("luarocks.pack")
 local remove = require("luarocks.remove")
 local deps = require("luarocks.deps")
 
+util.add_run_function(make)
 make.help_summary = "Compile package in current directory using a rockspec."
 make.help_arguments = "[--pack-binary-rock] [<rockspec>]"
 make.help = [[
@@ -50,8 +51,7 @@ To install rocks, you'll normally want to use the "install" and
 -- @param name string: A local rockspec.
 -- @return boolean or (nil, string, exitcode): True if build was successful; nil and an
 -- error message otherwise. exitcode is optionally returned.
-function make.run(...)
-   local flags, rockspec = util.parse_flags(...)
+function make.command(flags, rockspec)
    assert(type(rockspec) == "string" or not rockspec)
    
    if not rockspec then

--- a/src/luarocks/make_manifest.lua
+++ b/src/luarocks/make_manifest.lua
@@ -12,6 +12,7 @@ local deps = require("luarocks.deps")
 local fs = require("luarocks.fs")
 local dir = require("luarocks.dir")
 
+util.add_run_function(make_manifest)
 make_manifest.help_summary = "Compile a manifest file for a repository."
 
 make_manifest.help = [[
@@ -26,9 +27,7 @@ make_manifest.help = [[
 -- the default local repository configured as cfg.rocks_dir is used.
 -- @return boolean or (nil, string): True if manifest was generated,
 -- or nil and an error message.
-function make_manifest.run(...)
-   local flags, repo = util.parse_flags(...)
-
+function make_manifest.command(flags, repo)
    assert(type(repo) == "string" or not repo)
    repo = repo or cfg.rocks_dir
   

--- a/src/luarocks/new_version.lua
+++ b/src/luarocks/new_version.lua
@@ -10,6 +10,7 @@ local persist = require("luarocks.persist")
 local fs = require("luarocks.fs")
 local type_check = require("luarocks.type_check")
 
+util.add_run_function(new_version)
 new_version.help_summary = "Auto-write a rockspec for a new version of a rock."
 new_version.help_arguments = "[--tag=<tag>] [<package>|<rockspec>] [<new_version>] [<new_url>]"
 new_version.help = [[
@@ -123,8 +124,7 @@ local function update_source_section(out_rs, url, tag, old_ver, new_ver)
    return true
 end
  
-function new_version.run(...)
-   local flags, input, version, url = util.parse_flags(...)
+function new_version.command(flags, input, version, url)
    if not input then
       local err
       input, err = util.get_default_rockspec()

--- a/src/luarocks/pack.lua
+++ b/src/luarocks/pack.lua
@@ -16,6 +16,7 @@ local dir = require("luarocks.dir")
 local manif = require("luarocks.manif")
 local search = require("luarocks.search")
 
+util.add_run_function(pack)
 pack.help_summary = "Create a rock, packing sources or binaries."
 pack.help_arguments = "{<rockspec>|<name> [<version>]}"
 pack.help = [[
@@ -191,8 +192,7 @@ end
 -- version may also be passed.
 -- @return boolean or (nil, string): true if successful or nil followed
 -- by an error message.
-function pack.run(...)
-   local flags, arg, version = util.parse_flags(...)
+function pack.command(flags, arg, version)
    assert(type(version) == "string" or not version)
    if type(arg) ~= "string" then
       return nil, "Argument missing. "..util.see_help("pack")

--- a/src/luarocks/path_cmd.lua
+++ b/src/luarocks/path_cmd.lua
@@ -7,6 +7,7 @@ local util = require("luarocks.util")
 local deps = require("luarocks.deps")
 local cfg = require("luarocks.cfg")
 
+util.add_run_function(path_cmd)
 path_cmd.help_summary = "Return the currently configured package path."
 path_cmd.help_arguments = ""
 path_cmd.help = [[
@@ -33,8 +34,7 @@ And on Windows:
 
 --- Driver function for "path" command.
 -- @return boolean This function always succeeds.
-function path_cmd.run(...)
-   local flags = util.parse_flags(...)
+function path_cmd.command(flags)
    local deps_mode = deps.get_deps_mode(flags)
    
    local lr_path, lr_cpath, lr_bin = cfg.package_paths(flags["tree"])

--- a/src/luarocks/purge.lua
+++ b/src/luarocks/purge.lua
@@ -14,6 +14,7 @@ local manif = require("luarocks.manif")
 local cfg = require("luarocks.cfg")
 local remove = require("luarocks.remove")
 
+util.add_run_function(purge)
 purge.help_summary = "Remove all installed rocks from a tree."
 purge.help_arguments = "--tree=<tree> [--old-versions]"
 purge.help = [[
@@ -30,9 +31,7 @@ assume a default tree.
                 overridden with the flag --force.
 ]]
 
-function purge.run(...)
-   local flags = util.parse_flags(...)
-   
+function purge.command(flags)
    local tree = flags["tree"]
 
    if type(tree) ~= "string" then

--- a/src/luarocks/refresh_cache.lua
+++ b/src/luarocks/refresh_cache.lua
@@ -7,6 +7,7 @@ local util = require("luarocks.util")
 local cfg = require("luarocks.cfg")
 local cache = require("luarocks.cache")
 
+util.add_run_function(refresh_cache)
 refresh_cache.help_summary = "Refresh local cache of a remote rocks server."
 refresh_cache.help_arguments = "[--from=<server>]"
 refresh_cache.help = [[
@@ -15,8 +16,7 @@ If not given, the default server set in the upload_server variable
 from the configuration file is used instead.
 ]]
 
-function refresh_cache.run(...)
-   local flags = util.parse_flags(...)
+function refresh_cache.command(flags)
    local server, upload_server = cache.get_upload_server(flags["server"])
    if not server then return nil, upload_server end
    local download_url = cache.get_server_urls(server, upload_server)

--- a/src/luarocks/remove.lua
+++ b/src/luarocks/remove.lua
@@ -14,6 +14,7 @@ local cfg = require("luarocks.cfg")
 local manif = require("luarocks.manif")
 local fs = require("luarocks.fs")
 
+util.add_run_function(remove)
 remove.help_summary = "Uninstall a rock."
 remove.help_arguments = "[--force|--force-fast] <name> [<version>]"
 remove.help = [[
@@ -136,9 +137,7 @@ end
 -- may also be given.
 -- @return boolean or (nil, string, exitcode): True if removal was
 -- successful, nil and an error message otherwise. exitcode is optionally returned.
-function remove.run(...)
-   local flags, name, version = util.parse_flags(...)
-   
+function remove.command(flags, name, version)
    if type(name) ~= "string" then
       return nil, "Argument missing, see help."
    end

--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -11,6 +11,7 @@ local deps = require("luarocks.deps")
 local cfg = require("luarocks.cfg")
 local util = require("luarocks.util")
 
+util.add_run_function(search)
 search.help_summary = "Query the LuaRocks servers."
 search.help_arguments = "[--source] [--binary] { <name> [<version>] | --all }"
 search.help = [[
@@ -420,9 +421,7 @@ end
 -- @param version string or nil: a version may also be passed.
 -- @return boolean or (nil, string): True if build was successful; nil and an
 -- error message otherwise.
-function search.run(...)
-   local flags, name, version = util.parse_flags(...)
-   
+function search.command(flags, name, version)
    if flags["all"] then
       name, version = "", nil
    end

--- a/src/luarocks/show.lua
+++ b/src/luarocks/show.lua
@@ -10,6 +10,8 @@ local path = require("luarocks.path")
 local deps = require("luarocks.deps")
 local fetch = require("luarocks.fetch")
 local manif = require("luarocks.manif")
+
+util.add_run_function(show)
 show.help_summary = "Show information about an installed rock."
 
 show.help = [[
@@ -103,8 +105,7 @@ end
 -- @param name or nil: an existing package name.
 -- @param version string or nil: a version may also be passed.
 -- @return boolean: True if succeeded, nil on errors.
-function show.run(...)
-   local flags, name, version = util.parse_flags(...)
+function show.command(flags, name, version)
    if not name then
       return nil, "Argument missing. "..util.see_help("show")
    end

--- a/src/luarocks/unpack.lua
+++ b/src/luarocks/unpack.lua
@@ -11,6 +11,7 @@ local build = require("luarocks.build")
 local dir = require("luarocks.dir")
 local cfg = require("luarocks.cfg")
 
+util.add_run_function(unpack)
 unpack.help_summary = "Unpack the contents of a rock."
 unpack.help_arguments = "[--force] {<rock>|<name> [<version>]}"
 unpack.help = [[
@@ -149,9 +150,7 @@ end
 -- version may also be passed.
 -- @return boolean or (nil, string): true if successful or nil followed
 -- by an error message.
-function unpack.run(...)
-   local flags, name, version = util.parse_flags(...)
-
+function unpack.command(flags, name, version)
    assert(type(version) == "string" or not version)
    if type(name) ~= "string" then
       return nil, "Argument missing. "..util.see_help("unpack")

--- a/src/luarocks/upload.lua
+++ b/src/luarocks/upload.lua
@@ -7,6 +7,7 @@ local pack = require("luarocks.pack")
 local cfg = require("luarocks.cfg")
 local Api = require("luarocks.upload.api")
 
+util.add_run_function(upload)
 upload.help_summary = "Upload a rockspec to the public rocks repository."
 upload.help_arguments = "[--skip-pack] [--api-key=<key>] [--force] <rockspec>"
 upload.help = [[
@@ -20,8 +21,7 @@ upload.help = [[
                  increment the revision number instead.
 ]]
 
-function upload.run(...)
-   local flags, fname = util.parse_flags(...)
+function upload.command(flags, fname)
    if not fname then
       return nil, "Missing rockspec. "..util.see_help("upload")
    end

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -228,6 +228,13 @@ function util.forward_flags(flags, ...)
    return unpack(out)
 end
 
+-- Adds legacy 'run' function to a command module.
+-- @param command table: command module with 'command' function,
+-- the added 'run' function calls it after parseing command-line arguments.
+function util.add_run_function(command)
+   command.run = function(...) return command.command(util.parse_flags(...)) end
+end
+
 --- Merges contents of src on top of dst's contents.
 -- @param dst Destination table, which will receive src's contents.
 -- @param src Table which provides new contents to dst.

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -196,38 +196,6 @@ function util.parse_flags(...)
    return flags, unpack(out)
 end
 
---- Build a sequence of flags for forwarding from one command to
--- another (for example, from "install" to "build").
--- @param flags table: A table of parsed flags
--- @param ... string...: A variable number of flags to be checked
--- in the flags table. If no flags are passed as varargs, the
--- entire flags table is forwarded.
--- @return string... A variable number of strings
-function util.forward_flags(flags, ...)
-   assert(type(flags) == "table")
-   local out = {}
-   local filter = select('#', ...)
-   local function add_flag(flagname)
-      if flags[flagname] then
-         if flags[flagname] == true then
-            table.insert(out, "--"..flagname)
-         else
-            table.insert(out, "--"..flagname.."="..flags[flagname])
-         end
-      end
-   end
-   if filter > 0 then
-      for i = 1, filter do
-         add_flag(select(i, ...))
-      end
-   else
-      for flagname, _ in pairs(flags) do
-         add_flag(flagname)
-      end
-   end
-   return unpack(out)
-end
-
 -- Adds legacy 'run' function to a command module.
 -- @param command table: command module with 'command' function,
 -- the added 'run' function calls it after parseing command-line arguments.

--- a/src/luarocks/validate.lua
+++ b/src/luarocks/validate.lua
@@ -11,6 +11,7 @@ local build = require("luarocks.build")
 local install = require("luarocks.install")
 local util = require("luarocks.util")
 
+util.add_run_function(validate)
 validate.help_summary = "Sandboxed test of build/install of all packages in a repository."
 
 validate.help = [[
@@ -74,8 +75,7 @@ local function validate_rock(file)
    return ok, err, errcode
 end
 
-function validate.run(...)
-   local flags, repo = util.parse_flags(...)
+function validate.command(flags, repo)
    repo = repo or cfg.rocks_dir
 
    util.printout("Verifying contents of "..repo)

--- a/src/luarocks/write_rockspec.lua
+++ b/src/luarocks/write_rockspec.lua
@@ -11,6 +11,7 @@ local persist = require("luarocks.persist")
 local type_check = require("luarocks.type_check")
 local util = require("luarocks.util")
 
+util.add_run_function(write_rockspec)
 write_rockspec.help_summary = "Write a template for a rockspec file."
 write_rockspec.help_arguments = "[--output=<file> ...] [<name>] [<version>] [<url>|<path>]"
 write_rockspec.help = [[
@@ -224,9 +225,7 @@ local function rockspec_cleanup(rockspec)
    rockspec.name = nil
 end
 
-function write_rockspec.run(...)
-   local flags, name, version, url_or_dir = util.parse_flags(...)
-
+function write_rockspec.command(flags, name, version, url_or_dir)
    if not name then
       url_or_dir = "."
    elseif not version then


### PR DESCRIPTION
Instead of 'run' function command modules now have 'command' function that accepts already parsed flags. Code mutating original args in 'luarocks.command_line' and 'util.forward_flags' are no longer needed.

There was a comment saying that the old 'run' interface, although undocumented, is used by some people. It may be irrelevant now but I've added an utility function wrapping the new interface to provide 'run'. It's called on all command modules.