### PR TITLE
Improve error on archive unpack error

### DIFF
--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -344,7 +344,8 @@ function fetch.get_sources(rockspec, extract, dest_dir)
    if extract then
       local ok, err = fs.change_dir(store_dir)
       if not ok then return nil, err end
-      fs.unpack_archive(rockspec.source.file)
+      ok, err = fs.unpack_archive(rockspec.source.file)
+      if not ok then return nil, err end
       if not fs.exists(rockspec.source.dir) then
          return nil, "Directory "..rockspec.source.dir.." not found inside archive "..rockspec.source.file, "source.dir", source_file, store_dir
       end

--- a/src/luarocks/fs/unix/tools.lua
+++ b/src/luarocks/fs/unix/tools.lua
@@ -192,8 +192,7 @@ function tools.unpack_archive(archive)
       -- Ignore .lua and .c files; they don't need to be extracted.
       return true
    else
-      local ext = archive:match(".*(%..*)")
-      return false, "Unrecognized filename extension "..(ext or "")
+      return false, "Couldn't extract archive "..archive..": unrecognized filename extension"
    end
    if not ok then
       return false, "Failed extracting "..archive

--- a/src/luarocks/fs/win32/tools.lua
+++ b/src/luarocks/fs/win32/tools.lua
@@ -204,8 +204,7 @@ function tools.unpack_archive(archive)
       -- Ignore .lua and .c files; they don't need to be extracted.
       return true
    else
-      local ext = archive:match(".*(%..*)")
-      return false, "Unrecognized filename extension "..(ext or "")
+      return false, "Couldn't extract archive "..archive..": unrecognized filename extension"
    end
    if not ok then
       return false, "Failed extracting "..archive


### PR DESCRIPTION
Currently fetch ignores archive unpack errors and simply checks if expected source directory exists. This may be a workaround to support an undocumented feature that allows to use an url pointing directly to a `.lua` or `.c` file, but `fs.unpack_archive` already ignores such files.

With this PR unpack errors are detected earlier, and use a different message for unrecognized archive extension, which is a common error that happens when wrongly using `https://` in place of `git+https://`:

`Directory <name> not found inside archive <name>.git`

becomes

`Couldn't extract archive <name>.git: unrecognized extension`.