### PR TITLE
Make package.path and package.cpath unique in win32 bin scripts.

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -403,7 +403,7 @@ local defaults = {
 
 if cfg.platforms.windows then
    local full_prefix = (site_config.LUAROCKS_PREFIX or (os.getenv("PROGRAMFILES")..[[\LuaRocks]]))
-   extra_luarocks_module_dir = full_prefix.."\\lua\\?.lua"
+   extra_luarocks_module_dir = full_prefix.."/lua/?.lua"
 
    home_config_file = home_config_file and home_config_file:gsub("\\","/")
    defaults.fs_use_modules = false

--- a/src/luarocks/fs/win32.lua
+++ b/src/luarocks/fs/win32.lua
@@ -130,6 +130,8 @@ function win32.wrap_script(file, dest, name, version)
    local wrapname = fs.is_dir(dest) and dest.."/"..base or dest
    wrapname = wrapname..".bat"
    local lpath, lcpath = cfg.package_paths()
+   lpath = util.remove_path_dupes(lpath, ";")
+   lcpath = util.remove_path_dupes(lcpath, ";")
    local wrapper = io.open(wrapname, "w")
    if not wrapper then
       return nil, "Could not open "..wrapname.." for writing."


### PR DESCRIPTION
It happens that I manually installed Lua and LuaRocks in the follow structure:

```
{ROOT}
|   config.lua
|   lua.exe
|   lua53.dll
|   lua53.lib
|   luacheck.bat
|   luarocks
|   luarocks.bat
|
+---cmod
|       lfs.dll
|
+---doc
|
+---include
|       lauxlib.h
|       lua.h
|       lua.hpp
|       luaconf.h
|       lualib.h
|
+---lua
|   +---luacheck
|   |       analyze.lua
|   |       ...
|   |       version.lua
|   |
|   \---luarocks
|       |   add.lua
|       |   ...
|       |   write_rockspec.lua
|       |
|       +---build
|       |       builtin.lua
|       |       cmake.lua
|       |       command.lua
|       |       make.lua
|       |
|       +---fetch
|       |       cvs.lua
|       |       ...
|       |       svn.lua
|       |
|       +---fs
|       |   |   lua.lua
|       |   |   unix.lua
|       |   |   win32.lua
|       |   |
|       |   +---unix
|       |   |       tools.lua
|       |   |
|       |   \---win32
|       |           tools.lua
|       |
|       +---tools
|       |       patch.lua
|       |       tar.lua
|       |       zip.lua
|       |
|       \---upload
|               api.lua
|               multipart.lua
|
+---rocks
|   |   manifest
|   |
|   +---luacheck
|   |   \---0.15.1-1
|   |       |   luacheck-0.15.1-1.rockspec
|   |       |   rock_manifest
|   |       |
|   |       +---bin
|   |       |       luacheck
|   |       |
|   |       +---doc
|   |       \---lua
|   \---luafilesystem
|       \---1.6.3-2
|           |   luafilesystem-1.6.3-2.rockspec
|           |   rock_manifest
|           |
|           +---doc
|           \---tests
|
\---tools
        7z.exe
        ...
        wget.exe
```

in `config.lua`:

```lua
rocks_trees = {
  {
    root="{ROOT}",
    bin_dir="{ROOT}",
    lib_dir="{ROOT}/cmod",
    lua_dir="{ROOT}/lua"
  }
}
```

in `site_config.lua`:

```
site_config.LUAROCKS_PREFIX=[[{ROOT}]]
```

* The `extra_luarocks_module_dir` (`site_config.LUAROCKS_PREFIX`..'lua/?.lua'  == `{ROOT}/lua/?.lua`)
* And `rocks_trees.lua_dir` .. '/?.lua' == `{ROOT}/lua/?.lua`

That is in this case of configuration. `extra_luarocks_module_dir` is duplicated with lua directory for the tree.

So I:

1. add 2 lines in `src/luarocks/fs/win32.lua` to remove duplicated path in `lpath` and `lcpath`.
2. use `/` instead of `\\` in extra_luarocks_module_dir.
