### PR TITLE
Detect Lua version in install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -287,56 +287,32 @@ end
 -- ***********************************************************
 -- Detect Lua
 -- ***********************************************************
-local function look_for_interpreter (directory)
+local function look_for_interpreter(directory)
+	local names = {S"lua$LUA_VERSION.exe", S"lua$LUA_SHORTV.exe", "lua.exe", "luajit.exe"}
+	local directories
 	if vars.LUA_BINDIR then
-        -- if LUA_BINDIR is specified, it must be there, otherwise we fail
-		if exists( S"$LUA_BINDIR\\lua$LUA_VERSION.exe" ) then
-			vars.LUA_INTERPRETER = S"lua$LUA_VERSION.exe"
-			print(S"       Found $LUA_BINDIR\\$LUA_INTERPRETER")
-			return true
-		elseif exists( S"$LUA_BINDIR\\lua$LUA_SHORTV.exe" ) then
-			vars.LUA_INTERPRETER = S"lua$LUA_SHORTV.exe"
-			print(S"       Found $LUA_BINDIR\\$LUA_INTERPRETER")
-			return true
-		elseif exists(S"$LUA_BINDIR\\lua.exe") then
-			vars.LUA_INTERPRETER = "lua.exe"
-			print(S"       Found $LUA_BINDIR\\$LUA_INTERPRETER")
-			return true
-		elseif exists(S"$LUA_BINDIR\\luajit.exe") then
-			vars.LUA_INTERPRETER = "luajit.exe"
-			print(S"       Found $LUA_BINDIR\\$LUA_INTERPRETER")
-			return true
+		-- If LUA_BINDIR is specified, look only in that directory.
+		directories = {vars.LUA_BINDIR}
+	else
+		-- Try candidate directory and its `bin` subdirectory.
+		directories = {directory, directory .. "\\bin"}
+	end
+
+	for _, dir in ipairs(directories) do
+		for _, name in ipairs(names) do
+			local full_name = dir .. "\\" .. name
+			if exists(full_name) then
+				vars.LUA_INTERPRETER = name
+				vars.LUA_BINDIR = dir
+				print("       Found " .. full_name)
+				return true
+			end
 		end
+	end
+
+	if vars.LUA_BINDIR then
 		die(S"Lua executable lua.exe, luajit.exe, lua$LUA_SHORTV.exe or lua$LUA_VERSION.exe not found in $LUA_BINDIR")
 	end
-
-	for _, e in ipairs{ [[\]], [[\bin\]] } do
-		if exists(directory..e.."\\lua"..vars.LUA_VERSION..".exe") then
-			vars.LUA_INTERPRETER = S"lua$LUA_VERSION.exe"
-			vars.LUA_BINDIR = directory .. e
-			print("       Found ."..e..vars.LUA_INTERPRETER)
-			return true
-
-		elseif exists(directory..e.."\\lua"..vars.LUA_SHORTV..".exe") then
-			vars.LUA_INTERPRETER = S"lua$LUA_SHORTV.exe"
-			vars.LUA_BINDIR = directory .. e
-			print("       Found ."..e..vars.LUA_INTERPRETER)
-			return true
-
-		elseif exists(directory..e.."\\lua.exe") then
-			vars.LUA_INTERPRETER = "lua.exe"
-			vars.LUA_BINDIR = directory..e
-			print("       Found ."..e..vars.LUA_INTERPRETER)
-			return true
-
-		elseif exists(directory..e.."\\luajit.exe") then
-			vars.LUA_INTERPRETER = "luajit.exe"
-			vars.LUA_BINDIR = directory..e
-			print("       Found ."..e..vars.LUA_INTERPRETER)
-			return true
-		end
-	end
-	--print("      No Lua interpreter found")
 	return false
 end
 

--- a/install.bat
+++ b/install.bat
@@ -151,7 +151,7 @@ Configuring the destinations:
                
 Configuring the Lua interpreter:
 /LV [version]  Lua version to use; either 5.1, 5.2, or 5.3.
-               Default is 5.1
+               Default is auto-detected.
 /LUA [dir]     Location where Lua is installed - e.g. c:\lua\5.1\
                If not provided, the installer will search the system
                path and some default locations for a valid Lua

--- a/install.bat
+++ b/install.bat
@@ -316,29 +316,29 @@ local function look_for_interpreter(directory)
 	return false
 end
 
-local function look_for_link_libraries (directory)
+local function look_for_link_libraries(directory)
+	local directories
 	if vars.LUA_LIBDIR then
-		for name in vars.LUA_LIB_NAMES:gmatch("[^%s]+") do
-			print(S"    checking for $LUA_LIBDIR\\"..name)
-			if exists(vars.LUA_LIBDIR.."\\"..name) then
-				vars.LUA_LIBNAME = name
-				print("       Found "..name)
-				return true
-			end
-		end
-		die(S"link library (one of; $LUA_LIB_NAMES) not found in $LUA_LIBDIR")
+		directories = {vars.LUA_LIBDIR}
+	else
+		directories = {directory, directory .. "\\lib", directory .. "\\bin"}
 	end
 
-	for _, e in ipairs{ [[\]], [[\lib\]], [[\bin\]]} do
+	for _, dir in ipairs(directories) do
 		for name in vars.LUA_LIB_NAMES:gmatch("[^%s]+") do
-			print("    checking for "..directory..e.."\\"..name)
-			if exists(directory..e.."\\"..name) then
-				vars.LUA_LIBDIR = directory .. e
+			local full_name = dir .. "\\" .. name
+			print("    checking for " .. full_name)
+			if exists(full_name) then
+				vars.LUA_LIBDIR = dir
 				vars.LUA_LIBNAME = name
-				print("       Found "..name)
+				print("       Found " .. name)
 				return true
 			end
 		end
+	end
+
+	if vars.LUA_LIBDIR then
+		die(S"link library (one of; $LUA_LIB_NAMES) not found in $LUA_LIBDIR")
 	end
 	return false
 end

--- a/install.bat
+++ b/install.bat
@@ -343,30 +343,32 @@ local function look_for_link_libraries(directory)
 	return false
 end
 
-local function look_for_headers (directory)
+local function look_for_headers(directory)
+	local directories
 	if vars.LUA_INCDIR then
-		print(S"    checking for $LUA_INCDIR\\lua.h")
-		if exists(S"$LUA_INCDIR\\lua.h") then
-			print("       Found lua.h")
-			return true
-		end
-		die(S"lua.h not found in $LUA_INCDIR")
+		directories = {vars.LUA_INCDIR}
+	else
+		directories = {
+			directory .. S"\\include\\lua\\$LUA_VERSION",
+			directory .. S"\\include\\lua$LUA_SHORTV",
+			directory .. S"\\include\\lua$LUA_VERSION",
+			directory .. "\\include",
+			directory
+		}
 	end
 
-	for _, e in ipairs{ 
-        S([[\include\lua\$LUA_VERSION]]), 
-        S([[\include\lua$LUA_SHORTV]]), 
-        S([[\include\lua$LUA_VERSION]]), 
-        S([[\include\$LUA_VERSION]]), 
-        [[\include\]],
-        [[\]], 
-      } do
-		print("    checking for "..directory..e.."\\lua.h")
-		if exists(directory..e.."\\lua.h") then
-			vars.LUA_INCDIR = directory..e
+	for _, dir in ipairs(directories) do
+		local full_name = dir .. "\\lua.h"
+		print("    checking for " .. full_name)
+		if exists(full_name) then
+			vars.LUA_INCDIR = dir
 			print("       Found lua.h")
 			return true
 		end
+	end
+
+	if vars.LUA_INCDIR then
+		die(S"lua.h not found in $LUA_INCDIR")
 	end
 	return false
 end


### PR DESCRIPTION
Implements #602. The first four commits are almost pure refactoring (visible changes should be that there will be no trailing backslashes in autodetected LUA_BINDIR, LUA_INCDIR and LUA_LIBDIR), but I'd like to have them reviewed since the code may not be very well covered with tests right now. It may be useful to test @robooo's Windows testsuite with this before merging.