### PR TITLE
Run Windows tests with MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,23 +7,23 @@ environment:
 
   matrix:
   - LUA: "lua 5.1"
-    COMPILER: "msvc"
-  - LUA: "lua 5.2"
-    COMPILER: "msvc"
-  - LUA: "lua 5.3"
-    COMPILER: "msvc"
-  - LUA: "luajit 2.0"
-    COMPILER: "msvc"
-  - LUA: "luajit 2.1"
-    COMPILER: "msvc"
+    COMPILER: "vs"
   - LUA: "lua 5.1"
     COMPILER: "mingw"
   - LUA: "lua 5.2"
+    COMPILER: "vs"
+  - LUA: "lua 5.2"
     COMPILER: "mingw"
+  - LUA: "lua 5.3"
+    COMPILER: "vs"
   - LUA: "lua 5.3"
     COMPILER: "mingw"
   - LUA: "luajit 2.0"
+    COMPILER: "vs"
+  - LUA: "luajit 2.0"
     COMPILER: "mingw"
+  - LUA: "luajit 2.1"
+    COMPILER: "vs"
   - LUA: "luajit 2.1"
     COMPILER: "mingw"
 
@@ -36,7 +36,7 @@ init:
 before_build:
   - set PATH=C:\Python27\Scripts;%PATH% # Add directory containing 'pip' to PATH
   - pip install hererocks
-  - hererocks env --%LUA% -rlatest
+  - hererocks env --%LUA% -rlatest --target=%COMPILER%
   - call env\bin\activate
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@ init:
 # Setup Lua development/build environment
 # Make VS 2015 command line tools available
 - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %platform%
+# Add MinGW compiler to the path
+- set PATH=C:\MinGW\bin;%PATH%
 
 before_build:
   - set PATH=C:\Python27\Scripts;%PATH% # Add directory containing 'pip' to PATH
@@ -43,7 +45,6 @@ build_script:
   - luarocks install busted 1> NUL 2> NUL
 
 test_script:
-  - set PATH=C:\MinGW\bin;%PATH% # Add MinGW compiler to the path
   - busted --lpath=.//?.lua --exclude-tags=ssh,unix,mock -Xhelper appveyor,%COMPILER%
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,25 @@ environment:
 
   matrix:
   - LUA: "lua 5.1"
+    COMPILER: "msvc"
   - LUA: "lua 5.2"
+    COMPILER: "msvc"
   - LUA: "lua 5.3"
+    COMPILER: "msvc"
   - LUA: "luajit 2.0"
+    COMPILER: "msvc"
   - LUA: "luajit 2.1"
+    COMPILER: "msvc"
+  - LUA: "lua 5.1"
+    COMPILER: "mingw"
+  - LUA: "lua 5.2"
+    COMPILER: "mingw"
+  - LUA: "lua 5.3"
+    COMPILER: "mingw"
+  - LUA: "luajit 2.0"
+    COMPILER: "mingw"
+  - LUA: "luajit 2.1"
+    COMPILER: "mingw"
 
 
 init:
@@ -28,7 +43,8 @@ build_script:
   - luarocks install busted 1> NUL 2> NUL
 
 test_script:
-  - busted --lpath=.//?.lua --exclude-tags=ssh,unix,mock -Xhelper appveyor
+  - set PATH=C:\MinGW\bin;%PATH% # Add MinGW compiler to the path
+  - busted --lpath=.//?.lua --exclude-tags=ssh,unix,mock -Xhelper appveyor,%COMPILER%
 
 after_test:
   - if "%LUA%"=="lua 5.1" (luarocks show bit32 || luarocks install bit32)

--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -92,7 +92,7 @@ describe("LuaRocks build tests #blackbox #b_build", function()
 
    describe("LuaRocks build - basic builds", function()
       it("LuaRocks build luadoc", function()
-         assert.is_true(run.luarocks_bool(test_env.quiet("build luadoc")))
+         assert.is_true(run.luarocks_bool("build luadoc --verbose"))
       end)
       
       it("LuaRocks build luacov diff version", function()

--- a/spec/build_spec.lua
+++ b/spec/build_spec.lua
@@ -92,7 +92,7 @@ describe("LuaRocks build tests #blackbox #b_build", function()
 
    describe("LuaRocks build - basic builds", function()
       it("LuaRocks build luadoc", function()
-         assert.is_true(run.luarocks_bool("build luadoc --verbose"))
+         assert.is_true(run.luarocks_bool(test_env.quiet("build luadoc")))
       end)
       
       it("LuaRocks build luacov diff version", function()

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -468,6 +468,7 @@ if cfg.platforms.mingw32 then
    defaults.variables.LD = "mingw32-gcc"
    defaults.variables.CFLAGS = "-O2"
    defaults.variables.LIBFLAG = "-shared"
+   defaults.makefile = "Makefile"
    defaults.external_deps_patterns = {
       bin = { "?.exe", "?.bat" },
       -- mingw lookup list from http://stackoverflow.com/a/15853231/1793220

--- a/test/test_environment.lua
+++ b/test/test_environment.lua
@@ -171,6 +171,10 @@ function test_env.set_args()
          test_env.APPVEYOR_OPENSSL = "OPENSSL_LIBDIR=C:\\OpenSSL-Win32\\lib OPENSSL_INCDIR=C:\\OpenSSL-Win32\\include"
       elseif argument:find("^os=") then
          test_env.TEST_TARGET_OS = argument:match("^os=(.*)$")
+      elseif argument == "mingw" then
+         test_env.MINGW = true
+      elseif argument == "msvc" then
+         test_env.MINGW = false
       else
          help()
       end
@@ -629,11 +633,8 @@ local function install_luarocks(install_env_vars)
    local testing_paths = test_env.testing_paths
    title("Installing LuaRocks")
    if test_env.TEST_TARGET_OS == "windows" then
-      if test_env.LUA_V then 
-         assert(execute_bool("install.bat /LUA " .. testing_paths.luadir .. " /LV " .. test_env.LUA_V .. " /P " .. testing_paths.testing_lrprefix .. " /NOREG /NOADMIN /F /Q /CONFIG " .. testing_paths.testing_lrprefix .. "/etc/luarocks", false, install_env_vars))
-      else
-         assert(execute_bool("install.bat /LUA " .. testing_paths.luadir .. " /P " .. testing_paths.testing_lrprefix .. " /NOREG /NOADMIN /F /Q /CONFIG " .. testing_paths.testing_lrprefix .. "/etc/luarocks", false, install_env_vars))
-      end
+      local compiler_flag = test_env.MINGW and "/MW" or ""
+      assert(execute_bool("install.bat /LUA " .. testing_paths.luadir .. " " .. compiler_flag .. " /P " .. testing_paths.testing_lrprefix .. " /NOREG /NOADMIN /F /Q /CONFIG " .. testing_paths.testing_lrprefix .. "/etc/luarocks", false, install_env_vars))
       assert(execute_bool(testing_paths.win_tools .. "/cp " .. testing_paths.testing_lrprefix .. "/lua/luarocks/site_config* " .. testing_paths.src_dir .. "/luarocks/site_config.lua"))
    else
       local configure_cmd = "./configure --with-lua=" .. testing_paths.luadir .. " --prefix=" .. testing_paths.testing_lrprefix

--- a/test/test_environment.lua
+++ b/test/test_environment.lua
@@ -173,7 +173,7 @@ function test_env.set_args()
          test_env.TEST_TARGET_OS = argument:match("^os=(.*)$")
       elseif argument == "mingw" then
          test_env.MINGW = true
-      elseif argument == "msvc" then
+      elseif argument == "vs" then
          test_env.MINGW = false
       else
          help()


### PR DESCRIPTION
Adds MinGW to the test matrix in Appveyor.
Note commit af41c31 — it's a change in the LuaRocks defaults, but I think it makes sense because Makefile.win is a leftover from Kepler days, and those are usually nmake makefiles for MSVC; any rockspecs depending on that default value were most likely broken with MinGW.

This PR also removes "/LV" from the testsuite, thanks to #605.