### PR TITLE
Update deployment target for MAC OS X 10.12

### DIFF
--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -560,7 +560,9 @@ if cfg.platforms.macosx then
    defaults.variables.STATFLAG = "-f '%A'"
    local version = io.popen("sw_vers -productVersion"):read("*l")
    version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
-   if version >= 10 then
+   if version >= 12 then
+      version = 12
+   elseif version >= 10 then
       version = 8
    elseif version >= 5 then
       version = 5


### PR DESCRIPTION
In of MAC OSX v10.12, support for `clock_gettime` was added. This causes builds with luarocks to fail on MAC OS X 10.12 for C modules that use `clock_gettime` since the `MAC_OSX_VERSION_MIN_REQUIRED` macro does not reflect version 10.12, but 10.8 instead. This is due to luarocks setting the deployment target to 10.8 for MAC OS X version 10.10 and later. Hence, for MAC OS X versions 10.12 and later, the deployment target should be at least 10.12.