### PR TITLE
Fix of openssl location on TravisCI OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install python; gem install bundler; brew install openssl; brew link openssl --force;fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;fi
   - pip install hererocks
   - hererocks lua_install -r^ --$LUA
   - export PATH=$PATH:$PWD/lua_install/bin # Add directory with all installed binaries to PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install python; gem install bundler; brew install openssl; brew link openssl --force;fi
   - pip install hererocks
   - hererocks lua_install -r^ --$LUA
   - export PATH=$PATH:$PWD/lua_install/bin # Add directory with all installed binaries to PATH

--- a/test/test_environment.lua
+++ b/test/test_environment.lua
@@ -203,7 +203,7 @@ function test_env.set_args()
       if execute_bool("sw_vers") then 
          test_env.TEST_TARGET_OS = "osx"
          if test_env.TRAVIS then
-            test_env.OPENSSL_DIRS = "OPENSSL_LIBDIR=C:\\OpenSSL-Win32\\lib OPENSSL_INCDIR=C:\\OpenSSL-Win32\\include"
+            test_env.OPENSSL_DIRS = "OPENSSL_LIBDIR=/usr/local/opt/openssl/lib OPENSSL_INCDIR=/usr/local/opt/openssl/include"
          end
       elseif execute_output("uname -s") == "Linux" then
          test_env.TEST_TARGET_OS = "linux"

--- a/test/test_environment.lua
+++ b/test/test_environment.lua
@@ -202,6 +202,9 @@ function test_env.set_args()
 
       if execute_bool("sw_vers") then 
          test_env.TEST_TARGET_OS = "osx"
+         if test_env.TRAVIS then
+            test_env.OPENSSL_DIRS = "OPENSSL_LIBDIR=C:\\OpenSSL-Win32\\lib OPENSSL_INCDIR=C:\\OpenSSL-Win32\\include"
+         end
       elseif execute_output("uname -s") == "Linux" then
          test_env.TEST_TARGET_OS = "linux"
       else


### PR DESCRIPTION
Travis on OS X platform couldn't locate openssl headers, now the path needs to be specified in LR command.