### PR TITLE
Fix manif.find_{current,next}_provider returning "untracked" incorrectly

### DIFF
--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -464,6 +464,11 @@ function manif.zip_manifests()
    end
 end
 
+local function relative_path(from_dir, to_file)
+   -- It is assumed that `from_dir` is prefix of `to_file`.
+   return (to_file:sub(#from_dir + 1):gsub("^[\\/]*", ""))
+end
+
 local function find_providers(file, root)
    assert(type(file) == "string")
    root = root or cfg.root_dir
@@ -479,13 +484,13 @@ local function find_providers(file, root)
 
    if util.starts_with(file, deploy_lua) then
       manifest_tbl = manifest.modules
-      key = path.path_to_module(file:sub(#deploy_lua+1):gsub("\\", "/"))
+      key = path.path_to_module(relative_path(deploy_lua, file):gsub("\\", "/"))
    elseif util.starts_with(file, deploy_lib) then
       manifest_tbl = manifest.modules
-      key = path.path_to_module(file:sub(#deploy_lib+1):gsub("\\", "/"))
+      key = path.path_to_module(relative_path(deploy_lib, file):gsub("\\", "/"))
    elseif util.starts_with(file, deploy_bin) then
       manifest_tbl = manifest.commands
-      key = file:sub(#deploy_bin+1):gsub("^[\\/]*", "")
+      key = relative_path(deploy_bin, file)
    else
       assert(false, "Assertion failed: '"..file.."' is not a deployed file.")
    end


### PR DESCRIPTION
`find_providers` function used by `manif.find_current_provider`
and `manif.find_next_provider` needs relative path from a directory
an installed file is deployed in (bin dir, lua dir, or lib dir) to the file.
It then uses that path as key in manifest, converting it to
module name beforehand for lua files and lib files.

It happened to leave a leading slash in this relative path for
lua and lib files. `path.path_to_module` has a workaround stripping
leading dots caused by leading slashes. However, if the file
doesn't have `.lua` extension, slashes are not converted to dots
and the workaround doesn't trigger.

The issue results in files falsely considered "untracked" and backed-up
when reinstalling a different version of a rock,
see sailorproject/sailor#138.

The fix is to use correct relative paths without leading slashes.