### PR TITLE
Relax Lua version detection to support Ravi

### DIFF
--- a/configure
+++ b/configure
@@ -226,8 +226,8 @@ then
 fi
 
 detect_lua_version() {
-   detected_lua=`$1 -e 'print(_VERSION:sub(5))' 2> /dev/null`
-   if [ "$detected_lua" = "5.1" -o "$detected_lua" = "5.2" -o "$detected_lua" = "5.3" ]
+   detected_lua=`$1 -e 'print(_VERSION:match(" (5%.[123])$"))' 2> /dev/null`
+   if [ "$detected_lua" != "nil" ]
    then
       echo "Lua version detected: $detected_lua"
       if [ "$LUA_VERSION_SET" != "yes" ]

--- a/install.bat
+++ b/install.bat
@@ -262,7 +262,7 @@ local function detect_lua_version(interpreter_path)
 	local full_version = handler:read("*a")
 	handler:close()
 
-	local version = full_version:match("^Lua (5%.[123])$")
+	local version = full_version:match(" (5%.[123])$")
 	if not version then
 		return nil, "unknown interpreter version '" .. full_version .. "'"
 	end

--- a/src/luarocks/cfg.lua
+++ b/src/luarocks/cfg.lua
@@ -18,7 +18,7 @@ package.loaded["luarocks.cfg"] = cfg
 
 local util = require("luarocks.util")
 
-cfg.lua_version = _VERSION:sub(5)
+cfg.lua_version = _VERSION:match(" (5%.[123])$") or "5.1"
 local version_suffix = cfg.lua_version:gsub("%.", "_")
 
 -- Load site-local global configurations


### PR DESCRIPTION
Ravi has `"Ravi 5.3"` as `_VERSION`. Don't use `_VERSION:sub(5)` to get Lua
version, match `" (5%.[123])$"` instead.

(with this patch I got sailor working under ravi very easily using experimental hererocks support: https://github.com/mpeterv/hererocks/tree/ravi :smile: )