### PR TITLE
Remove packages without manifest rebuild

### DIFF
--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -414,31 +414,31 @@ end
 function manif.update_manifest(name, version, repo, deps_mode)
    assert(type(name) == "string")
    assert(type(version) == "string")
-   repo = path.rocks_dir(repo or cfg.root_dir)
+   local rocks_dir = path.rocks_dir(repo or cfg.root_dir)
    assert(type(deps_mode) == "string")
    
    if deps_mode == "none" then deps_mode = cfg.deps_mode end
 
-   local manifest, err = manif.load_manifest(repo)
+   local manifest, err = manif.load_manifest(rocks_dir)
    if not manifest then
       util.printerr("No existing manifest. Attempting to rebuild...")
-      local ok, err = manif.make_manifest(repo, deps_mode)
+      local ok, err = manif.make_manifest(rocks_dir, deps_mode)
       if not ok then
          return nil, err
       end
-      manifest, err = manif.load_manifest(repo)
+      manifest, err = manif.load_manifest(rocks_dir)
       if not manifest then
          return nil, err
       end
    end
 
-   local results = {[name] = {[version] = {{arch = "installed", repo = repo}}}}
+   local results = {[name] = {[version] = {{arch = "installed", repo = rocks_dir}}}}
 
    local ok, err = store_results(results, manifest)
    if not ok then return nil, err end
 
    update_dependencies(manifest, deps_mode)
-   return save_table(repo, "manifest", manifest)
+   return save_table(rocks_dir, "manifest", manifest)
 end
 
 function manif.zip_manifests()

--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -419,7 +419,7 @@ function manif.update_manifest(name, version, repo, deps_mode)
    
    if deps_mode == "none" then deps_mode = cfg.deps_mode end
 
-   local manifest, err = manif.load_manifest(rocks_dir)
+   local manifest, err = manif_core.load_local_manifest(rocks_dir)
    if not manifest then
       util.printerr("No existing manifest. Attempting to rebuild...")
       local ok, err = manif.make_manifest(rocks_dir, deps_mode)

--- a/src/luarocks/manif.lua
+++ b/src/luarocks/manif.lua
@@ -422,14 +422,10 @@ function manif.update_manifest(name, version, repo, deps_mode)
    local manifest, err = manif_core.load_local_manifest(rocks_dir)
    if not manifest then
       util.printerr("No existing manifest. Attempting to rebuild...")
-      local ok, err = manif.make_manifest(rocks_dir, deps_mode)
-      if not ok then
-         return nil, err
-      end
-      manifest, err = manif.load_manifest(rocks_dir)
-      if not manifest then
-         return nil, err
-      end
+      -- Manifest built by `manif.make_manifest` should already
+      -- include information about given name and version,
+      -- no need to update it.
+      return manif.make_manifest(rocks_dir, deps_mode)
    end
 
    local results = {[name] = {[version] = {{arch = "installed", repo = rocks_dir}}}}

--- a/src/luarocks/repos.lua
+++ b/src/luarocks/repos.lua
@@ -312,7 +312,7 @@ function repos.deploy_files(name, version, wrap_bin_scripts, deps_mode)
       return nil, err
    end
 
-   return manif.update_manifest(name, version, nil, deps_mode)
+   return manif.add_to_manifest(name, version, nil, deps_mode)
 end
 
 --- Delete a package from the local repository.
@@ -398,7 +398,7 @@ function repos.delete_version(name, version, deps_mode, quick)
       return true
    end
 
-   return manif.make_manifest(cfg.rocks_dir, deps_mode)
+   return manif.remove_from_manifest(name, version, nil, deps_mode)
 end
 
 return repos


### PR DESCRIPTION
Implements a function that removes a version from manifest without rebuilding it. Also some minor refactoring and an optimization: exit from manifest updating functions early if it was missing and rebuilt.