### PR TITLE
Update install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,7 +1,7 @@
-rem=nil --[[--lua
+rem=rem --[[--lua
 @setlocal&  set luafile="%~f0" & if exist "%~f0.bat" set luafile="%~f0.bat"
 @win32\lua5.1\bin\lua5.1.exe %luafile% %*&  exit /b 0
-rem=nil ]]
+rem=rem ]]
 
 local vars = {}
 


### PR DESCRIPTION
The problem here is that `%errorlevel%` is set on `exit /b ]]` and you pass it something funny. By adding `rem=rem` you can reuse a hack and get it still to execute correctly. You don't actually need to even set `rem=rem` you can just pass it nil, since nothing else in the script uses rem.