### PR TITLE
allow to work without debug library

### DIFF
--- a/src/luarocks/argparse.lua
+++ b/src/luarocks/argparse.lua
@@ -2067,6 +2067,9 @@ function Parser:parse(args)
 end
 
 local function xpcall_error_handler(err)
+   if not debug then
+      return tostring(err)
+   end
    return tostring(err) .. "\noriginal " .. debug.traceback("", 2):sub(2)
 end
 

--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -146,6 +146,9 @@ local function process_server_args(args)
 end
 
 local function error_handler(err)
+   if not debug then
+      return err
+   end
    local mode = "Arch.: " .. (cfg and cfg.arch or "unknown")
    if package.config:sub(1, 1) == "\\" then
       if cfg and cfg.fs_use_modules then

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -50,6 +50,9 @@ local platform_order = {
 }
 
 local function detect_sysconfdir()
+   if not debug then
+      return
+   end
    local src = debug.getinfo(1, "S").source:gsub("\\", "/"):gsub("/+", "/")
    if src:sub(1, 1) == "@" then
       src = src:sub(2)

--- a/src/luarocks/core/util.lua
+++ b/src/luarocks/core/util.lua
@@ -67,7 +67,10 @@ function util.show_table(t, tname, top_indent)
    local function basic_serialize(o)
       local so = tostring(o)
       if type(o) == "function" then
-         local info = debug.getinfo(o, "S")
+         local info = debug and debug.getinfo(o, "S")
+         if not info then
+            return ("%q"):format(so)
+         end
          -- info.name is nil because o is not a calling level
          if info.what == "C" then
             return ("%q"):format(so .. ", C function")

--- a/src/luarocks/loader.lua
+++ b/src/luarocks/loader.lua
@@ -43,8 +43,8 @@ else
    -- a global.
    -- Detect when being called via -lluarocks.loader; this is
    -- most likely a wrapper.
-   local info = debug.getinfo(2, "nS")
-   if info.what == "C" and not info.name then
+   local info = debug and debug.getinfo(2, "nS")
+   if info and info.what == "C" and not info.name then
       luarocks = { loader = loader }
       temporary_global = true
       -- For the other half of this hack,

--- a/src/luarocks/util.lua
+++ b/src/luarocks/util.lua
@@ -23,7 +23,6 @@ local unpack = unpack or table.unpack
 local pack = table.pack or function(...) return { n = select("#", ...), ... } end
 
 local scheduled_functions = {}
-local debug = require("debug")
 
 --- Schedule a function to be executed upon program termination.
 -- This is useful for actions such as deleting temporary directories
@@ -198,7 +197,7 @@ function util.this_program(default)
    local i = 1
    local last, cur = default, default
    while i do
-      local dbg = debug.getinfo(i,"S")
+      local dbg = debug and debug.getinfo(i,"S")
       if not dbg then break end
       last = cur
       cur = dbg.source


### PR DESCRIPTION
the use of [debug](https://www.lua.org/manual/5.4/manual.html#6.10) library could be not safe, or at least no recommended.

I want run code with a Lua interpreter compiled without this library `debug`.

at this time, it could be tested with :
```
$ hererocks Lua-5.1.1-nodebug --lua https://github.com/fperrad/lua-1.git@51nodebug --luarocks https://github.com/fperrad/luarocks@nodebug
$ hererocks Lua-5.2.3-nodebug --lua https://github.com/fperrad/lua-1.git@52nodebug --luarocks https://github.com/fperrad/luarocks@nodebug
$ hererocks Lua-5.3.6-nodebug --lua https://github.com/fperrad/lua-1.git@53nodebug --luarocks https://github.com/fperrad/luarocks@nodebug
$ hererocks Lua-5.4.3-nodebug --lua https://github.com/fperrad/lua-1.git@54nodebug --luarocks https://github.com/fperrad/luarocks@nodebug
```
