### PR TITLE
WIP: Add Unix manual pages

### DIFF
--- a/man/luarocks-build.1
+++ b/man/luarocks-build.1
@@ -1,55 +1,91 @@
 .Dd $Mdocdate: January 11 2023 $
-.Dt LUAROCKS-INSTALL 1
+.Dt LUAROCKS-BUILD 1
 .Os
 .Sh NAME
-.Nm luarocks-install
-.Nd install a rock
+.Nm luarocks-build
+.Nd build and install a rock
 
 .Sh SYNOPSIS
-.Nm luarocks install
+.Nm luarocks build
 .Bk -words
 .Op Fl h
+.Op Fl -only-deps
+.Op Fl -branch Ar name
+.Op Fl -pin
+.Op Fl -no-install
+.Op Fl -no-doc
+.Op Fl -pack-binary-rock
 .Op Fl -keep
 .Op Fl -force
 .Op Fl -force-fast
-.Op Fl -only-deps
-.Op Fl -no-doc
 .Op Fl -verify
+.Op Fl -sign
 .Op Fl -check-lua-versions
-.Op Fl -deps-mode Ar mode
 .Op Fl -no-manifest
-.Op Fl -pin
-.Ar rock
+.Op Fl -deps-mode Ar mode
+.Op rock
 .Op version
 .Ek
 
 .Sh DESCRIPTION
-.Nm luarocks install
-installs the rock named
+.Nm luarocks build
+builds and installs
 .Ar rock ,
-and if specified, version number
-.Ar version .
+along with its C code if any.
+.Pp
+.Ar rock
+could be a rockspec file, a source rock file, or the name of a rock to be fetched from a repository.
+If a
+.Ar version
+argument is given,
+.Nm luarocks build
+will build that version of
+.Ar rock .
+.Pp
+If the sources contain a luarocks.lock file,
+.Nm luarocks build
+will use it as an authoritative source for exact versions of dependencies.
+.Pp
+If
+.Nm luarocks build
+is called without any arguments, it behaves as
+.Sy luarocks make .
 .Pp
 The options are as follows:
 .Bl -tag -width keyword
 .It Fl h
 Show a help message and exit.
+.It Fl -only-deps , Fl -deps-only
+Install only the dependencies of the rock.
+.It Fl -pin
+Create a luarocks.lock file listing the exact versions of each dependency found for this rock (recursively), and store it in the rock's directory. Ignores any existing luarocks.lock file in the rock's sources.
+.It Fl -no-install
+Build the rock without installing it.
+.It Fl -no-doc
+Install the rock without its documentation.
+.It Fl -pack-binary-rock
+Do not install
+.Ar rock .
+Instead, produce a .rock file with the contents of compilation in the current directory.
 .It Fl -keep
 Do not remove previously installed versions of the rock after building a new one. This behavior can be made permanent by setting keep_other_versions=true in the configuration file.
 .It Fl -force
 If --keep is not specified, force removal of previously installed versions even if it would break dependencies.
 .It Fl -force-fast
 Similar to --force, but performs a forced removal without reporting dependency issues.
-.It Fl -only-deps , Fl -deps-only
-Install only the dependencies of the rock.
 .It Fl -no-doc
 Install the rock without its documentation.
 .It Fl -verify
 Verify signature of the rockspec or src.rock being built. If the rockspec or src.rock is being downloaded,
 .Sy luarocks
 will attempt to download the signature as well. Otherwise, the signature file should be already available locally in the same directory. You need the signer’s public key in your local keyring for this option to work properly.
+.It Fl -sign
+Produce a signature file for the generated .rock file when used with
+.Fl -pack-binary-rock .
 .It Fl -check-lua-versions
 If the rock can't be found, check the repository and report if it is available for another Lua version.
+.It Fl -no-manifest
+Skip creating/updating the manifest.
 .It Fl -deps-mode Ar mode
 Specify how to handle dependencies. Four modes are supported:
 .Pp
@@ -74,17 +110,18 @@ Run
 .Sy luarocks
 with no arguments to see your
 list of rocks trees.
-.It Fl -no-manifest
-Skip creating/updating the manifest.
-.It Fl -pin
-If the installed rock is a Lua module, create a luarocks.lock file listing the exact versions of each dependency found for this rock (recursively), and store it in the rock's directory. Ignores any existing luarocks.lock file in the rock's sources.
 .El
 
 .Sh EXAMPLES
 .Pp
-Install version 1.7.0-1 of the
-.Sq luafilesystem
-rock into the system tree:
+Build a specific rockspec, but don't install it:
 .Pp
-.Dl # luarocks install luafilesystem 1.7.0-1
+.Dl $ luarocks build --no-install mysupercoolrock-0.1.0-1.rockspec
 .Pp
+Find a rockspec automatically and build and install it, without its documentation:
+.Pp
+.Dl $ luarocks build --no-doc
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-make 1

--- a/man/luarocks-doc.1
+++ b/man/luarocks-doc.1
@@ -1,0 +1,61 @@
+.Dd $Mdocdate: March 29 2023 $
+.Dt LUAROCKS-DOC 1
+.Os
+.Sh NAME
+.Nm luarocks-doc
+.Nd show documentation for a rock
+
+.Sh SYNOPSIS
+.Nm luarocks doc
+.Bk -words
+.Op Fl h
+.Op Fl -home
+.Op Fl -list
+.Op Fl -porcelain
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks doc
+shows the documentation for the installed rock named
+.Ar rock .
+If a version argument is given,
+.Nm luarocks doc
+uses the documentation for that specific version of
+.Ar rock .
+.Pp
+If
+.Nm luarocks doc
+is not passed any flags, it attempts to load the documentation using a series of heuristics.
+If flags
+.Em are
+passed,
+.Nm luarocks doc
+returns only the desired information.
+.Pp
+If you are looking for a way to get information on a rock, see the
+.Xr luarocks-show 1
+command instead.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -home
+Open the rock's home page.
+.It Fl -list
+List the files only; don't show their contents.
+.It Fl -porcelain
+Produce machine-friendly output.
+.El
+
+.Sh EXAMPLES
+.Pp
+View the documentation of version 1.1.2-1 of the xml package (as long as it's installed):
+.Pp
+.Dl $ luarocks doc xml 1.1.2-1
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-show 1

--- a/man/luarocks-download.1
+++ b/man/luarocks-download.1
@@ -1,0 +1,52 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-DOWNLOAD 1
+.Os
+.Sh NAME
+.Nm luarocks-download
+.Nd download a rock
+
+.Sh SYNOPSIS
+.Nm luarocks download
+.Bk -words
+.Op Fl h
+.Op Fl -source | Fl -rockspec | Fl arch Ar arch
+.Op Fl -all
+.Op Fl -check-lua-versions
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks download
+downloads the rock named
+.Ar rock ,
+and if specified, version number
+.Ar version .
+The downloaded rock is placed in the current working directory.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -all
+If there are multiple matches, download all files.
+.It Fl -source
+Download the .src.rock file if it's available.
+.It Fl -rockspec
+Download the .rockspec file if it's available.
+.It Fl -arch Ar arch
+Download the rock for the
+.Ar arch
+architecture.
+.It Fl -check-lua-versions
+If the rock can't be found, check the repository and report if it's available for another Lua version.
+.El
+
+.Sh EXAMPLES
+.Pp
+Download the rockspec for the
+.Sq lua-cjson
+rock:
+.Pp
+.Dl # luarocks download --rockspec lua-cjson
+.Pp

--- a/man/luarocks-help.1
+++ b/man/luarocks-help.1
@@ -1,0 +1,41 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-HELP 1
+.Os
+.Sh NAME
+.Nm luarocks-help
+.Nd get help on luarocks commands
+
+.Sh SYNOPSIS
+.Nm luarocks help
+.Bk -words
+.Op Fl h
+.Op command
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks help
+outputs help on the
+.Sy luarocks
+command named
+.Ar command .
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.El
+
+.Sh EXAMPLES
+.Pp
+Get general
+.Sy luarocks
+help:
+.Pp
+.Dl $ luarocks help
+.Pp
+Get help about the
+.Sq doc
+command:
+.Pp
+.Dl $ luarocks help doc
+.Pp

--- a/man/luarocks-install.1
+++ b/man/luarocks-install.1
@@ -1,0 +1,89 @@
+.Dd $Mdocdate: January 10 2023 $
+.Dt LUAROCKS-INSTALL 1
+.Os
+.Sh NAME
+.Nm luarocks-install
+.Nd install a rock
+.Sh SYNOPSIS
+.Nm luarocks install
+.Bk -words
+.Op Fl h
+.Op Fl -keep
+.Op Fl -force
+.Op Fl -force-fast
+.Op Fl -only-deps
+.Op Fl -no-doc
+.Op Fl -verify
+.Op Fl -check-lua-versions
+.Op Fl -deps-mode Ar mode
+.Op Fl -no-manifest
+.Op Fl -pin
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks install
+installs the rock named
+.Ar rock ,
+and if specified, version number
+.Ar version .
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -keep
+Do not remove previously installed versions of the rock after building a new one. This behavior can be made permanent by setting keep_other_versions=true in the configuration file.
+.It Fl -force
+If --keep is not specified, force removal of previously installed versions even if it would break dependencies.
+.It Fl -force-fast
+Similar to --force, but performs a forced removal without reporting dependency issues.
+.It Fl -only-deps , Fl -deps-only
+Install only the dependencies of the rock.
+.It Fl -no-doc
+Install the rock without its documentation.
+.It Fl -verify
+Verify signature of the rockspec or src.rock being built. If the rockspec or src.rock is being downloaded,
+.Sy luarocks
+will attempt to download the signature as well. Otherwise, the signature file should be already available locally in the same directory. You need the signer’s public key in your local keyring for this option to work properly.
+.It Fl -check-lua-versions
+If the rock can't be found, check repository and report if it is available for another Lua version.
+.It Fl -deps-mode Ar mode
+Specify how to handle dependencies. Four modes are supported:
+.Pp
+.Bl -bullet
+.It
+.Sy all
+- use all trees from the rocks_trees list for finding dependencies
+.It
+.Sy one
+- use only the current tree (possibly set with --tree)
+.It
+.Sy order
+- use trees based on order (use the current tree and all trees below it on the rocks_trees list)
+.It
+.Sy none
+- ignore dependencies altogether.
+.El
+.Pp
+The default mode may be set with the deps_mode entry in the configuration file. The current default is
+.Ar one .
+Run
+.Sy luarocks
+with no arguments to see your
+list of rocks trees.
+.It Fl -no-manifest
+Skip creating/updating the manifest.
+.It Fl -pin
+If the installed rock is a Lua module, create a luarocks.lock file listing the exact versions of each dependency found for this rock (recursively), and store it in the rock's directory. Ignores any existing luarocks.lock file in the rock's sources.
+.El
+
+.Sh EXAMPLES
+.Pp
+Install version 1.7.0-1 of the
+.Sq luafilesystem
+rock into the system tree:
+.Pp
+.Dl # luarocks install luafilesystem 1.7.0-1
+.Pp

--- a/man/luarocks-make.1
+++ b/man/luarocks-make.1
@@ -1,0 +1,125 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-MAKE 1
+.Os
+.Sh NAME
+.Nm luarocks-make
+.Nd build a rock in the current directory
+
+.Sh SYNOPSIS
+.Nm luarocks make
+.Bk -words
+.Op Fl h
+.Op Fl -no-install
+.Op Fl -no-doc
+.Op Fl -pack-binary-rock
+.Op Fl -keep
+.Op Fl -force
+.Op Fl -force-fast
+.Op Fl -verify
+.Op Fl -sign
+.Op Fl -check-lua-versions
+.Op Fl -pin
+.Op Fl -no-manifest
+.Op Fl -only-deps
+.Op Fl -deps-mode Ar mode
+.Op rockspec
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks make
+builds sources in the current directory. Unlike
+.Sy luarocks build
+however, it does not fetch sources, but assumes everything is available in the current directory. Once building is finished,
+.Nm luarocks make
+will install the rock, unless the
+.Fl -no-install
+flag is given.
+.Pp
+If no
+.Ar rockspec
+argument is given, it looks for a rockspec in the current directory and in subdirectories
+.Sq rockspec/
+and
+.Sq rockspecs/ ,
+picking the rockspec with the newest version or without a version name. If rockspecs for different rocks are found or there are several rockspecs without a version number, you must specify
+.Ar rockspec
+through the command-line.
+.Pp
+This command is useful as a tool for debugging rockspecs. To install rocks, you'll normally want to use the
+.Sy luarocks install
+and
+.Sy luarocks build
+commands. See their manuals for details.
+.Pp
+If the current directory contains a luarocks.lock file, it is used as the authoritative source for exact version of dependencies. The
+.Fl -pin
+flag overrides and recreates this file scanning dependency based on ranges.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -no-install
+Build the rock without installing it.
+.It Fl -no-doc
+Install the rock without its documentation.
+.It Fl -pack-binary-rock
+Do not install
+.Ar rock .
+Instead, produce a .rock file with the contents of compilation in the current directory.
+.It Fl -keep
+Do not remove previously installed versions of the rock after building a new one. This behavior can be made permanent by setting keep_other_versions=true in the configuration file.
+.It Fl -force
+If --keep is not specified, force removal of previously installed versions even if it would break dependencies.
+.It Fl -force-fast
+Similar to --force, but performs a forced removal without reporting dependency issues.
+.It Fl -verify
+Verify signature of the rockspec or src.rock being built. If the rockspec or src.rock is being downloaded,
+.Sy luarocks
+will attempt to download the signature as well. Otherwise, the signature file should be already available locally in the same directory. You need the signer’s public key in your local keyring for this option to work properly.
+.It Fl -sign
+Produce a signature file for the generated .rock file when used with
+.Fl -pack-binary-rock .
+.It Fl -check-lua-versions
+If the rock can't be found, check the repository and report if it is available for another Lua version.
+.It Fl -pin
+Create a luarocks.lock file listing the exact versions of each dependency found for this rock (recursively), and store it in the rock's directory. Ignores any existing luarocks.lock file in the rock's sources.
+.It Fl -no-manifest
+Skip creating/updating the manifest.
+.It Fl -only-deps , Fl -deps-only
+Install only the dependencies of the rock.
+.It Fl -deps-mode Ar mode
+Specify how to handle dependencies. Four modes are supported:
+.Pp
+.Bl -bullet
+.It
+.Sy all :
+use all trees from the rocks_trees list for finding dependencies
+.It
+.Sy one :
+use only the current tree (possibly set with --tree)
+.It
+.Sy order :
+use trees based on order (use the current tree and all trees below it on the rocks_trees list)
+.It
+.Sy none :
+ignore dependencies altogether.
+.El
+.Pp
+The default mode may be set with the deps_mode entry in the configuration file. The current default is
+.Ar one .
+Run
+.Sy luarocks
+with no arguments to see your
+list of rocks trees.
+.El
+
+.Sh EXAMPLES
+.Pp
+Search for a rockspec and build it without installing it:
+.Pp
+.Dl $ luarocks make --no-install
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-build 1

--- a/man/luarocks-pack.1
+++ b/man/luarocks-pack.1
@@ -1,0 +1,54 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-PACK 1
+.Os
+.Sh NAME
+.Nm luarocks-pack
+.Nd create a rock
+
+.Sh SYNOPSIS
+.Nm luarocks pack
+.Bk -words
+.Op Fl h
+.Op Fl -sign
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks pack
+creates a source rock from a rockspec, or a binary rock from an installed package.
+.Pp
+If
+.Ar rock
+is the name of a rockspec file,
+.Nm luarocks pack
+will create a source rock from it.
+Otherwise if it is the name of an installed package,
+.Nm luarocks pack
+will create a binary rock, and the argument
+.Ar version
+may be given to specify a version of
+.Ar rock
+to pack.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -sign
+Produce a signature file as well.
+.El
+
+.Sh EXAMPLES
+.Pp
+Pack a source rock from a rockspec:
+.Pp
+.Dl $ luarocks pack mysuperawesomerock-0.1.0-1.rockspec
+.Pp
+Pack version 1.1.2-1 of the xml package into a binary rock (as long as the xml package is installed):
+.Pp
+.Dl $ luarocks pack xml 1.1.2-1
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-unpack 1

--- a/man/luarocks-remove.1
+++ b/man/luarocks-remove.1
@@ -1,0 +1,71 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-REMOVE 1
+.Os
+.Sh NAME
+.Nm luarocks-remove
+.Nd uninstall a rock
+
+.Sh SYNOPSIS
+.Nm luarocks remove
+.Bk -words
+.Op Fl h
+.Op Fl -force
+.Op Fl -force-fast
+.Op Fl -deps-mode Ar mode
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks remove
+removes the rock named
+.Ar rock ,
+and if specified, version number
+.Ar version .
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -force
+Force removal even if it would break dependencies.
+.It Fl -force-fast
+Similar to --force, but don't report dependency issues.
+.It Fl -deps-mode Ar mode
+Specify how to handle dependencies. Four modes are supported:
+.Pp
+.Bl -bullet
+.It
+.Sy all :
+use all trees from the rocks_trees list for finding dependencies
+.It
+.Sy one :
+use only the current tree (possibly set with --tree)
+.It
+.Sy order :
+use trees based on order (use the current tree and all trees below it on the rocks_trees list)
+.It
+.Sy none :
+ignore dependencies altogether.
+.El
+.Pp
+The default mode may be set with the deps_mode entry in the configuration file. The current default is
+.Ar one .
+Run
+.Sy luarocks
+with no arguments to see your
+list of rocks trees.
+.It Fl -no-manifest
+Skip creating/updating the manifest.
+.It Fl -pin
+If the removed rock is a Lua module, create a luarocks.lock file listing the exact versions of each dependency found for this rock (recursively), and store it in the rock's directory. Ignores any existing luarocks.lock file in the rock's sources.
+.El
+
+.Sh EXAMPLES
+.Pp
+Remove the
+.Sq luafilesystem
+rock:
+.Pp
+.Dl # luarocks remove luafilesystem
+.Pp

--- a/man/luarocks-show.1
+++ b/man/luarocks-show.1
@@ -1,0 +1,94 @@
+.Dd $Mshowdate: March 29 2023 $
+.Dt LUAROCKS-SHOW 1
+.Os
+.Sh NAME
+.Nm luarocks-show
+.Nd show information about an installed rock
+
+.Sh SYNOPSIS
+.Nm luarocks show
+.Bk -words
+.Op Fl h
+.Op Fl -build-deps
+.Op Fl -deps
+.Op Fl -home
+.Op Fl -issues
+.Op Fl -labels
+.Op Fl -modules
+.Op Fl -mversion
+.Op Fl -porcelain
+.Op Fl -rockspec
+.Op Fl -rock-dir
+.Op Fl -rock-license
+.Op Fl -rock-namespace
+.Op Fl -rock-tree
+.Op Fl -test-deps
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks show
+shows information about the (installed) rock named
+.Ar rock .
+If a version argument is given,
+.Nm luarocks show
+shows information for that specific version of
+.Ar rock .
+.Pp
+If
+.Nm luarocks show
+is not passed any flags, it shows all information about the module.
+If flags
+.Em are
+passed,
+.Nm luarocks show
+returns only the desired information.
+.Pp
+If you are looking for a way to view a rock's documentation, see the
+.Xr luarocks-doc 1
+command instead.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -build-deps
+Show packages the rock depends on for its building/compilation.
+.It Fl -deps
+Show packages the rock depends on.
+.It Fl -home
+Show the rock's home page.
+.It Fl -issues
+Show the URL for the rock's issue tracker.
+.It Fl -labels
+List the rock's labels.
+.It Fl -modules
+Show all modules that the package provides, as used by require().
+.It Fl -mversion
+Show the rock's version.
+.It Fl -porcelain
+Produce machine-friendly output.
+.It Fl -rockspec
+Show the path of the rock's rockspec file.
+.It Fl -rock-dir
+Show the data directory of the rock.
+.It Fl -rock-license
+Show the name of the license the rock is licensed under.
+.It Fl -rock-namespace
+Show the rock namespace.
+.It Fl -rock-tree
+Show the local tree where the rock is installed.
+.It Fl -test-deps
+Show packages the rock depends on for its tests.
+.El
+
+.Sh EXAMPLES
+.Pp
+Show information about version 1.1.2-1 of the xml package (as long as it's installed):
+.Pp
+.Dl $ luarocks show xml 1.1.2-1
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-doc 1

--- a/man/luarocks-unpack.1
+++ b/man/luarocks-unpack.1
@@ -1,0 +1,49 @@
+.Dd $Mdocdate: January 11 2023 $
+.Dt LUAROCKS-UNPACK 1
+.Os
+.Sh NAME
+.Nm luarocks-unpack
+.Nd unpack a rock
+
+.Sh SYNOPSIS
+.Nm luarocks unpack
+.Bk -words
+.Op Fl h
+.Op Fl -check-lua-versions
+.Op Fl -force
+.Ar rock
+.Op version
+.Ek
+
+.Sh DESCRIPTION
+.Nm luarocks pack
+unpacks the contents of a rock into a newly created directory.
+The
+.Ar rock
+argument must be an already-packed rock, or the name of a rock in a rock server. In the latter case, the
+.Ar version
+argument can be used to specify the version of the rock to unpack.
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -check-lua-versions
+If the rock can't be found, check the repository and report back if it is available for another Lua version.
+.It Fl -force
+Don't produce an error if the output directory already exists; unpack the rock anyways.
+.El
+
+.Sh EXAMPLES
+.Pp
+Unpack a local rock:
+.Pp
+.Dl $ luarocks pack mysuperawesomerock-0.1.0-1.rock
+.Pp
+Unpack version 1.1.2-1 of the xml rock:
+.Pp
+.Dl $ luarocks unpack xml 1.1.2-1
+.Pp
+
+.Sh SEE ALSO
+.Xr luarocks-pack 1

--- a/man/luarocks.1
+++ b/man/luarocks.1
@@ -1,0 +1,154 @@
+.Dd $Mdocdate: January 10 2023 $
+.Dt LUAROCKS 1
+.Os
+.Sh NAME
+.Nm luarocks
+.Nd manage Lua modules and packages
+.Sh SYNOPSIS
+.Nm luarocks
+.Bk -words
+.Op Fl h
+.Op Fl -version
+.Op Fl -server Ar server
+.Op Fl -only-server Ar server
+.Op Fl -only-sources Ar url
+.Op Fl -namespace Ar namespace
+.Op Fl -lua-dir Ar prefix
+.Op Fl -lua-version Ar version
+.Op Fl -tree Ar tree
+.Op Fl -local
+.Op Fl -global
+.Op Fl -no-project
+.Op Fl -dev
+.Op Fl -verbose
+.Op Fl -timeout Ar seconds
+.Ar command
+.Ek
+
+.Sh DESCRIPTION
+The
+.Nm
+utility manages Lua modules and packages downloaded from
+luarocks.org (or optionally, another server).
+.Pp
+The options are as follows:
+.Bl -tag -width keyword
+.It Fl h
+Show a help message and exit.
+.It Fl -version
+Show version information and exit.
+.It Fl -dev
+Enable the sub-repositories in rocks servers for rockspecs of in-development versions.
+.It Fl -server Ar server
+Fetch rocks/rockspecs from
+.Ar server
+(takes priority over config file).
+.It Fl -only-server Ar server
+Fetch rocks/rockspecs from
+.Ar server
+only (overrides any entries in the config file).
+.It Fl -only-sources Ar server
+Restrict downloads to paths matching
+.Ar url .
+.It Fl -namespace Ar namespace
+Set the used rocks server namespace to
+.Ar namespace .
+.It Fl -lua-dir Ar prefix
+Set the used Lua installation to
+.Ar prefix .
+.It Fl -lua-version Ar version
+Set the used Lua version to
+.Ar version .
+.It Fl -tree Ar tree
+Set the tree to operate on to
+.Ar tree .
+.It Fl -local
+Instead of using the system tree, use the tree in the user's home directory.
+.It Fl -global
+Use the system tree when local_by_default is set to true in the configuration file.
+.It Fl -no-project
+Do not use project tree even if running from a project folder.
+.It Fl -verbose
+Display verbose output of commands executed.
+.It Fl -timeout Ar seconds
+Set the timeout in seconds on network operations to
+.Ar seconds .
+0 means	no timeout (wait forever). The default is 30.
+.El
+
+.Pp
+The following commands are available:
+.Bl -tag -width keyword
+.It Xr luarocks-help 1
+Show help for commands.
+.It Xr luarocks-install 1
+Install a rock.
+.It Xr luarocks-build 1
+Build/compile a rock.
+.It Xr luarocks-download 1
+Download a specific rock file from a rocks server.
+.It Xr luarocks-remove 1
+Uninstall a rock.
+.It Xr luarocks-purge 1
+Remove all installed rocks from a tree.
+.It Xr luarocks-search 1
+Query the LuaRocks servers.
+.It Xr luarocks-list 1
+List all currently installed rocks.
+.It Xr luarocks-show 1
+Show information about an installed rock.
+.It Xr luarocks-doc 1
+Show documentation for an installed rock.
+.It Xr luarocks-init 1
+Initialize a directory for a Lua project using LuaRocks.
+.It Xr luarocks-make 1
+Compile a package in the current directory using a rockspec.
+.It Xr luarocks-lint 1
+Check the syntax of a rockspec.
+.It Xr luarocks-pack 1
+Create a rock, packing sources or binaries.
+.It Xr luarocks-unpack 1
+Unpack the contents of a rock.
+.It Xr luarocks-upload 1
+Upload a rockspec to the public rocks repository.
+.It Xr luarocks-test 1
+Run the test suite in the current directory.
+.It Xr luarocks-write_rockspec 1
+Write a template for a rockspec file.
+.It Xr luarocks-new_version 1
+Automatically write a rockspec for a new version of a rock.
+.It Xr luarocks-config 1
+Query information about the LuaRocks configuration.
+.It Xr luarocks-which 1
+Print which file corresponds to a given module name.
+.It Xr luarocks-path 1
+Return the currently configured package path.
+.It Xr luarocks-completion 1
+Output a shell completion script.
+.El
+
+.Sh EXIT STATUS
+.Pp
+The
+.Nm
+utility exits 0 on success, and >0 if an error occurs.
+
+.Sh EXAMPLES
+.Pp
+Search the LuaRocks servers for
+.Sq xml :
+.Pp
+.Dl $ luarocks search xml
+.Pp
+Install the
+.Sq luasocket
+rock into the local tree:
+.Pp
+.Dl $ luarocks install --local luasocket
+.Pp
+Show information about the
+.Sq luaposix
+rock:
+.Pp
+.Dl $ luarocks show luaposix
+.Pp


### PR DESCRIPTION
This pull request adds Unix manual pages for each `luarocks` command.
A large amount of the content in these manuals are derived from the output of the `luarocks help` command.

I have a few questions:
 - Temporarily, I have put the manual pages in /man. What directory *should* they be in?
 - In the luarocks.1 manual page, I ordered the commands by how useful I think they are, and how much they will be used. Is this okay?

I used the OpenBSD [mdoc](http://man.openbsd.org/mdoc) format over groff, as it is easier to write for manuals and requires no preprocessing.

Closes #1483.