### PR TITLE
fix: prevent crash when fs_use_modules is activated and LuaFileSystem already installed is too old

### DIFF
--- a/src/luarocks/fs/lua.lua
+++ b/src/luarocks/fs/lua.lua
@@ -16,6 +16,11 @@ local pack = table.pack or function(...) return { n = select("#", ...), ... } en
 local socket_ok, zip_ok, lfs_ok, md5_ok, posix_ok, bz2_ok, _
 local http, ftp, zip, lfs, md5, posix, bz2
 
+-- Minimum lfs version required to
+-- install and remove modules
+local lfs_min_version = '1.6.0'
+local lfs_at_least_min_ver = false
+
 if cfg.fs_use_modules then
    socket_ok, http = pcall(require, "socket.http")
    _, ftp = pcall(require, "socket.ftp")
@@ -24,6 +29,20 @@ if cfg.fs_use_modules then
    lfs_ok, lfs = pcall(require, "lfs")
    md5_ok, md5 = pcall(require, "md5")
    posix_ok, posix = pcall(require, "posix")
+
+   if lfs_ok then
+      local lfs_ver = lfs._VERSION
+      if lfs_ver then
+         local v = lfs_ver:match("(%d+%.%d+%.%d+)$")
+         if v then
+            lfs_at_least_min_ver = vers.parse_version(v) >= vers.parse_version(lfs_min_version)
+         end
+      end
+   end
+
+   if not lfs_at_least_min_ver then
+      lfs_ok = false
+   end
 end
 
 local patch = require("luarocks.tools.patch")


### PR DESCRIPTION
## Description

* Fixes #1819

* On Unix systems, at the moment, the default LuaRocks config uses `cfg.fs_use_modules = true` at [https://github.com/luarocks/luarocks/blob/99c57c8b2464550d6659cce43f84db83b17c4c15/src/luarocks/core/cfg.lua#L185](https://github.com/luarocks/luarocks/blob/99c57c8b2464550d6659cce43f84db83b17c4c15/src/luarocks/core/cfg.lua#L185)

which makes LuaRocks aware of LuaFileSystem (LFS) in the system to use it (e.g.: to install and remove modules). However, when the LFS version already installed is too old, a few expected APIs are not present (e.g.: (1) - `fs.lock_dir`, and (2) - `fs.attributes` with the second parameter being the string `"permissions"`).

Thus, when `cfg.fs_use_modules` is activated and the user has an ancient LFS version installed (e.g.: `1.5.0-3` or older), a LuaRocks crash may happen during the installation or removal of modules.

> [!NOTE]
> 
> Even though #1819 will not affect many users (see [https://repology.org/project/lua:luafilesystem/versions](https://repology.org/project/lua:luafilesystem/versions) and [https://repology.org/project/lua%3Afilesystem/information](https://repology.org/project/lua%3Afilesystem/information)), I found it to be a bit unusual to reproduce such crash conditions. Thus, merging this PR would avoid such a headache and loss of time in the future.

## Changes

1. CI: bump OpenSSL to 3.5.2 on Windows (it was updated again because CI was failing);
2. Guarded the module on `src/luarocks/fs/lua.lua` to employ LFS if, and only if, LFS is installed and its version is 1.6.0 or newer.

## Reproduction

The steps required to trigger the issue are:

1. Setup Lua 5.1 (or LuaJIT) on Unix;
2. Setup LuaRocks 3.12.2;
3. Install LuaFileSystem 1.5.0-3 (LuaJIT will fail on this step, but it is a compilation issue and thus unrelated);
4. Try to install **AND** remove a module (e.g.: `lua-cjson`): at this step, either install or remove operation will fail.

> [!NOTE]
> 
> For the analysis of this PR, I wrote a small GitHub workflow (login to GitHub and browse [https://github.com/luau-project/luarocks/actions/runs/17070093972](https://github.com/luau-project/luarocks/actions/runs/17070093972)) that acts in the following manner:

* In the `orig` job, it configures LuaRocks 3.12.2 and compares LFS versions `1.5.0-3` and `1.6.0-1`;
* In the `PR` job, it configures LuaRocks from this PR branch and again compares LFS versions `1.5.0-3` and `1.6.0-1`.

## Conclusion

Browsing the GitHub action runs, it can be seen that:

* On PUC-Lua 5.1, LuaRocks 3.12.2 crashes while trying to install a module (`lua-cjson`) in the presence of ancient LFS versions (`1.5.0-3` or older), as reported by #1819;
* The code on this PR is able to bypass the LFS limitation ignoring LFS on ancient versions.