### PR TITLE
Installation instructions for Unix should specify to run ./configure before make

### DIFF
--- a/docs/installation_instructions_for_unix.md
+++ b/docs/installation_instructions_for_unix.md
@@ -31,6 +31,7 @@ Then, to get Lua, either install it using your package manager of choice, or
 * To build and install Lua, run the following commands.
 
 ```
+-$ ./configure
 -$ make all test
 -$ sudo make install
 ```


### PR DESCRIPTION
`./configure` needs to be run before make commands.

(This addresses something I noticed while opening #1839 but does not fix it.)