### PR TITLE
.github/workflows: bump openssl version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       # The following env variables
       # only applies to Visual Studio
       LUAROCKS_DEPS_DIR: c:\external
-      LUAROCKS_DEPS_OPENSSL_VER: "3.5.1"
+      LUAROCKS_DEPS_OPENSSL_VER: "3.6.0"
       LUAROCKS_DEPS_ZLIB_VER: "1.3.1"
       # The following env variable
       # applies to both Visual Studio and MinGW-w64


### PR DESCRIPTION
This should fix our CI failure
<img width="1186" height="307" alt="image" src="https://github.com/user-attachments/assets/3b8f6900-6959-4b81-ace2-bcdadf7ae568" />
