### PR TITLE
Bump lua-zlib from 1.2 to 1.4 as part of Lua 5.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       # The following env variables
       # only applies to Visual Studio
       LUAROCKS_DEPS_DIR: c:\external
-      LUAROCKS_DEPS_OPENSSL_VER: "3.6.0"
+      LUAROCKS_DEPS_OPENSSL_VER: "3.6.1"
       LUAROCKS_DEPS_ZLIB_VER: "1.3.1"
       # The following env variable
       # applies to both Visual Studio and MinGW-w64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,11 +314,6 @@ jobs:
           cmake --build _build-zlib --config Release && ^
           cmake --install _build-zlib --config Release
 
-          IF "${{ matrix.COMPILER }}"=="vs" (
-            copy "${{ env.LUAROCKS_DEPS_DIR }}\lib\zlib.lib" ^
-              "${{ env.LUAROCKS_DEPS_DIR }}\lib\z.lib"
-          )
-
       - name: Restore bzip2 tarball
         if: ${{ matrix.COMPILER == 'vs' }}
         id: restore-bzip2-tarball

--- a/binary/Makefile.windows
+++ b/binary/Makefile.windows
@@ -57,7 +57,7 @@ $(WINDOWS_DEPS_DIR)/lib/libz.a: $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION)
 	cd $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION) && cp zlib.h zconf.h ../../$(WINDOWS_DEPS_DIR)/include
 	cd $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION) && $(MINGW_PREFIX)-strip -g libz.a
 	mkdir -p $(@D)
-	cd $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION) && cp libz.a ../../$(WINDOWS_DEPS_DIR)/lib
+	cd $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION) && cp libz.a ../../$(WINDOWS_DEPS_DIR)/lib/libzlib.a
 
 $(BUILD_WINDOWS_DEPS_DIR)/bzip2-$(BZIP2_VERSION).tar.gz:
 	mkdir -p $(@D)

--- a/binary/all_in_one
+++ b/binary/all_in_one
@@ -465,7 +465,7 @@ local function main()
       md5 = "md5",
       luasocket = "./binary/luasocket-3.1.0-1.rockspec",
       luasec = "./binary/luasec-1.3.2-1.rockspec",
-      ["lua-zlib"] = "./binary/lua-zlib-1.2-0.rockspec",
+      ["lua-zlib"] = "./binary/lua-zlib-1.4-0.rockspec",
       ["lua-bz2"] = "./binary/lua-bz2-0.2.1-1.rockspec",
       luaposix = if_platform("unix", "./binary/luaposix-35.1-1.rockspec"),
       luafilesystem = "luafilesystem",

--- a/binary/lua-zlib-1.4-0.rockspec
+++ b/binary/lua-zlib-1.4-0.rockspec
@@ -1,8 +1,8 @@
 package = "lua-zlib"
-version = "1.2-0"
+version = "1.4-0"
 source = {
    url = "git+https://github.com/brimworks/lua-zlib.git",
-   tag = "v1.2",
+   tag = "v1.4",
 }
 description = {
    summary = "Simple streaming interface to zlib for Lua.",
@@ -16,7 +16,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, <= 5.4"
+   "lua >= 5.1, <= 5.5"
 }
 external_dependencies = {
     ZLIB = {

--- a/binary/lua-zlib-1.4-0.rockspec
+++ b/binary/lua-zlib-1.4-0.rockspec
@@ -1,8 +1,8 @@
 package = "lua-zlib"
-version = "1.2-0"
+version = "1.4-0"
 source = {
    url = "git+https://github.com/brimworks/lua-zlib.git",
-   tag = "v1.2",
+   tag = "v1.4",
 }
 description = {
    summary = "Simple streaming interface to zlib for Lua.",
@@ -16,12 +16,11 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, <= 5.4"
+   "lua >= 5.1, <= 5.5"
 }
 external_dependencies = {
     ZLIB = {
-       header = "zlib.h",
-       library = "z",
+       header = "zlib.h"
     }
 }
 
@@ -33,7 +32,24 @@ build = {
          libraries = { "z" },
          defines = { "LZLIB_COMPAT" },
          incdirs = { "$(ZLIB_INCDIR)" },
-         libdirs = { "$(ZLIB_LIBDIR)" },
+         libdirs = { "$(ZLIB_LIBDIR)" }
       }
    },
+   platforms = {
+      windows = {
+         modules = {
+            zlib = {
+               libraries = { "zlib" }
+            }
+         }
+      },
+      mingw = {
+         modules = {
+            zlib = {
+               libraries = { "zlib1" },
+               libdirs = { "$(ZLIB_INCDIR)/../bin" }
+            }
+         }
+      }
+   }
 }

--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -1129,7 +1129,7 @@ function test_env.main()
       table.insert(urls, "/luasocket-${LUASOCKET}.src.rock")
       table.insert(urls, "/luasec-${LUASEC}.src.rock")
       table.insert(urls, "/md5-1.2-1.src.rock")
-      table.insert(urls, "/manifests/hisham/lua-zlib-1.2-0.src.rock")
+      table.insert(urls, "/manifests/hisham/lua-zlib-1.4-0.src.rock")
       table.insert(urls, "/manifests/hisham/lua-bz2-0.2.1.1-1.src.rock")
       rocks = {"luafilesystem", "luasocket", "luasec", "md5", "lua-zlib", "lua-bz2"}
       if test_env.TEST_TARGET_OS ~= "windows" then


### PR DESCRIPTION
## Description

Updates `lua-zlib` (1.2 &rightarrow; 1.4). Note: `lua-zlib` brought Lua 5.5 support on 1.4

> [!IMPORTANT]
> 
> CI is expected to fail due the version change (1.2 &rightarrow; 1.4) applied in the test environment [https://github.com/luarocks/luarocks/blob/47301d83aba58925e1b9594023621ebb27070cdb/spec/util/test_env.lua#L1132](https://github.com/luarocks/luarocks/blob/47301d83aba58925e1b9594023621ebb27070cdb/spec/util/test_env.lua#L1132)

* Once a new `.src.rock` upload on LuaRocks org happens for the new version ([binary/lua-zlib-1.4-0.rockspec](binary/lua-zlib-1.4-0.rockspec)) under `hisham` manifest, CI tests are expected to return to the pass state;

* A bump to OpenSSL version (3.6.0 &rightarrow; 3.6.1) was also applied to CI.

## Details

If you compare the few main `lua-zlib` changes from v1.2 tag to v1.4

```bash
diff -Naur lua-zlib-1.2/lua_zlib.c lua-zlib-1.4/lua_zlib.c
```

it can be seen that they were mostly cosmetic changes:

```diff
--- lua-zlib-1.2/lua_zlib.c	2017-10-07 12:26:37.000000000 -0300
+++ lua-zlib-1.4/lua_zlib.c	2026-01-03 21:19:29.000000000 -0300
@@ -21,7 +21,7 @@
 #endif
 
 #ifdef LZLIB_COMPAT
-/**************** lzlib compatibilty **********************************/
+/**************** lzlib compatibility **********************************/
 /* Taken from https://raw.githubusercontent.com/LuaDist/lzlib/93b88e931ffa7cd0a52a972b6b26d37628f479f3/lzlib.c */
 
 /************************************************************************
@@ -51,7 +51,7 @@
 
 /*
 ** =========================================================================
-** compile time options wich determine available functionality
+** compile time options which determine available functionality
 ** =========================================================================
 */
 
@@ -613,16 +613,16 @@
 
 static int lzstream_readline(lua_State *L) {
     lz_stream *s;
-    int sucess;
+    int success;
 
     s = lzstream_check(L, lua_upvalueindex(1), LZ_INFLATE);
-    sucess = lz_read_line(L, s);
+    success = lz_read_line(L, s);
 
     if (s->error != Z_OK) {
         return lz_pushresult(L, s);
     }
 
-    if (sucess) {
+    if (success) {
         return 1;
     } else {
         /* EOF */
@@ -924,7 +924,7 @@
  *
  * if no params, terminates the stream (as if we got empty string and Z_FINISH).
  */
-static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end)(z_streamp), char* name) {
+static int lz_filter_impl(lua_State *L, int (*filter)(z_streamp, int), int (*end)(z_streamp), const char* name) {
     int flush = Z_NO_FLUSH, result;
     z_stream* stream;
     luaL_Buffer buff;
@@ -1191,8 +1191,8 @@
 }
 
 static int lz_checksum_new(lua_State *L, checksum_t checksum, checksum_combine_t combine) {
-    lua_pushlightuserdata(L, checksum);
-    lua_pushlightuserdata(L, combine);
+    lua_pushlightuserdata(L, (void *)checksum);
+    lua_pushlightuserdata(L, (void *)combine);
     lua_pushnumber(L, checksum(0L, Z_NULL, 0));
     lua_pushnumber(L, 0);
     lua_pushcclosure(L, lz_checksum, 4);
@@ -1267,7 +1267,7 @@
 
     SETLITERAL("_COPYRIGHT", "Copyright (c) 2009-2016 Brian Maher");
     SETLITERAL("_DESCRIPTION", "Simple streaming interface to the zlib library");
-    SETLITERAL("_VERSION", "lua-zlib $Id: da57e91a3a58c7f514e2058feccea7a7b42db5e2 $  (tag: v1.2)");
+    SETLITERAL("_VERSION", "lua-zlib $Id: 7680c9e2cb89fde21519c1b81b7ff740bd2ca9e8 $");
 
     /* Expose this to lua so we can do a test: */
     SETINT("_TEST_BUFSIZ", LUAL_BUFFERSIZE);
```