### PR TITLE
ci: added a job to test the cross compilation of Windows binaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,51 @@ jobs:
         ./smoke_test.sh luarocks-dev.tar.gz binary
 
   ##############################################################################
+  WindowsBinaryBuild:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: gcc-mingw-w64-i686-posix
+            make-target: windows-binary-32
+            mingw-sysroot: /usr/i686-w64-mingw32
+
+          - package: gcc-mingw-w64-x86-64-posix
+            make-target: windows-binary-64
+            mingw-sysroot: /usr/x86_64-w64-mingw32
+
+    steps:
+    - uses: actions/checkout@main
+
+    # [!NOTE]:
+    #
+    # During tests, the exact same
+    # job (WindowsBinaryBuild)
+    # fails to build the cross compiler
+    # whenever we use Lua 5.4 provided
+    # by the packages `lua5.4 liblua5.4-dev`
+    # on Debian-based distros.
+    #
+    # On the other hand, installing Lua 5.4
+    # from source, as happens applying
+    # the `luarocks/gh-actions-lua@master`
+    # action below, everything runs as
+    # it should.
+    - uses: luarocks/gh-actions-lua@master
+      with:
+        luaVersion: 5.4
+
+    - name: Install cross compiler
+      run: sudo apt install ${{ matrix.package }}
+
+    - name: Configure LuaRocks to build the cross compiled binaries
+      run: ./configure "--with-lua=${{ github.workspace }}/.lua"
+
+    - name: Cross compile `luarocks.exe` and `luarocks-admin.exe` 
+      run: make "MINGW_SYSROOT=${{ matrix.mingw-sysroot }}" ${{ matrix.make-target }}
+
+  ##############################################################################
   WindowsTest:
     runs-on: "windows-latest"
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,7 +349,7 @@ jobs:
       # The following env variables
       # only applies to Visual Studio
       LUAROCKS_DEPS_DIR: c:\external
-      LUAROCKS_DEPS_OPENSSL_VER: "3.6.0"
+      LUAROCKS_DEPS_OPENSSL_VER: "3.6.1"
       LUAROCKS_DEPS_ZLIB_VER: "1.3.1"
       # The following env variable
       # applies to both Visual Studio and MinGW-w64

--- a/binary/Makefile.windows
+++ b/binary/Makefile.windows
@@ -46,7 +46,7 @@ $(WINDOWS_DEPS_DIR)/lib/libssl.a: $(BUILD_WINDOWS_DEPS_DIR)/openssl-$(OPENSSL_VE
 
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz:
 	mkdir -p $(@D)
-	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -OL https://www.zlib.net/zlib-$(ZLIB_VERSION).tar.gz
+	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -OL https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION): $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz
 	cd $(BUILD_WINDOWS_DEPS_DIR) && tar zxvpf zlib-$(ZLIB_VERSION).tar.gz
 $(WINDOWS_DEPS_DIR)/lib/libz.a: $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION)

--- a/binary/luasocket-3.1.0-1.rockspec
+++ b/binary/luasocket-3.1.0-1.rockspec
@@ -34,7 +34,7 @@ local function make_plat(plat)
     },
     mingw32 = {
       "LUASOCKET_DEBUG",
-      "LUASOCKET_INET_PTON",
+      -- "LUASOCKET_INET_PTON",
       "WINVER=0x0501"
     }
   }


### PR DESCRIPTION
## Description

Recently, the code responsible to generate the Windows binaries were changed (see [https://github.com/luarocks/luarocks/pull/1854](https://github.com/luarocks/luarocks/pull/1854)). Thus, in order to detect regression issues, this PR adds a CI job to test the cross compilation of Windows binaries.

## Changes

* Fixed LuaSocket rockspec to allow cross compilation of LuaRocks binaries (this change is present on [https://luarocks.org/manifests/lunarmodules/luasocket-3.1.0-1.rockspec](https://luarocks.org/manifests/lunarmodules/luasocket-3.1.0-1.rockspec));
* Fixed zlib download URL, because zlib 1.3.2 was released and the previous 1.3.1 URL is not available anymore. According to zlib website, all tarballs released so far can be found on [https://www.zlib.net/fossils/](https://www.zlib.net/fossils/);

> [!IMPORTANT]
> 
> Recently, zlib 1.3.2 was released bringing improvements and fixes. However, zlib 1.3.2 also brought some breaking changes for MinGW / MinGW-w64 toolchains (including the cross compilers we use). For the moment, I think it is better to avoid the upgrade due [https://github.com/madler/zlib/issues/1202](https://github.com/madler/zlib/issues/1202).

* Added the `WindowsBinaryBuild` job to test the cross compilation of Windows binaries.. **Note**: it has the bare bones to serve as reference code for ([https://github.com/luarocks/luarocks/pull/1807](https://github.com/luarocks/luarocks/pull/1807));

* Bump OpenSSL to 3.6.1 for the Windows CI.