### PR TITLE
Handle macosx versions before 10.5

### DIFF
--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -509,6 +509,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
       elseif version >= vers.parse_version("10.5") then
          version = vers.parse_version("10.5")
       else
+         version = "10.3"
          defaults.gcc_rpath = false
       end
       defaults.variables.CC = "env MACOSX_DEPLOYMENT_TARGET="..tostring(version).." gcc"


### PR DESCRIPTION
Without this change, the `MACOSX_DEPLOYMENT_TARGET` gets set to a 3 tuple version number which trips up ld, when building on the PowerPC version of OS X 10.4.
`ld: warning unknown -macosx_version_min parameter value: 10.4.11 ignored (using 10.1)`

`rpath` support was introduced in the linker which shipped with 10.5 so it seems best to handle the version in the fall through else case.