### PR TITLE
fix: check if table entry is nil or not

### DIFF
--- a/spec/quick/config.q
+++ b/spec/quick/config.q
@@ -95,3 +95,41 @@ Warning: Failed finding Lua header lua.h (searched at /some/bad/path). You may n
 
 LuaRocks may not work correctly when building C modules using this configuration.
 --------------------------------------------------------------------------------
+
+
+
+================================================================================
+TEST: reports when getting a falsy boolean variable
+
+RUN: luarocks config local_by_default
+
+STDOUT:
+--------------------------------------------------------------------------------
+false
+--------------------------------------------------------------------------------
+
+
+
+================================================================================
+TEST: reports when setting a falsy boolean variable
+
+RUN: luarocks config local_by_default true
+
+STDOUT:
+--------------------------------------------------------------------------------
+Wrote
+local_by_default = true
+--------------------------------------------------------------------------------
+
+
+
+================================================================================
+TEST: reports when getting an unknown variable
+
+RUN: luarocks config foo
+EXIT: 1
+
+STDERR:
+--------------------------------------------------------------------------------
+Error: Unknown entry foo
+--------------------------------------------------------------------------------

--- a/src/luarocks/cmd/config.lua
+++ b/src/luarocks/cmd/config.lua
@@ -130,7 +130,7 @@ end
 
 local function print_entry(var, tbl, is_json)
    return traverse_varstring(var, tbl, function(t, k)
-      if not t[k] then
+      if t[k] == nil then
          return nil, "Unknown entry " .. k
       end
       local val = t[k]
@@ -151,7 +151,7 @@ end
 local function infer_type(var)
    local typ
    traverse_varstring(var, cfg, function(t, k)
-      if t[k] then
+      if t[k] ~= nil then
          typ = type(t[k])
       end
    end)


### PR DESCRIPTION
running 

```luarocks config local_by_default``` returns ```Error: Unknown entry local_by_default```

and running

```luarocks config local_by_default true``` writes it as a string to the config file: 
```lua 
local_by_default = "true"
```

Same is true to any bool var set as false.

This pr aims to fix this issue.