### PR TITLE
makedist: fix rockspec tag update producing invalid Lua

### DIFF
--- a/makedist
+++ b/makedist
@@ -59,7 +59,8 @@ then
    fi
    sed -i 's/"Configuring LuaRocks version .*"/"Configuring LuaRocks version '$version'..."/' configure
    sed -i 's/version = "[^"]*"/version = "'$version'-1"/' $ROCKSPEC
-   sed -i 's/\(   url = "[^"]*",\)/\1\n   tag = "v'$version'"/' $ROCKSPEC
+   sed -i '/^   tag = "[^"]*",\{0,1\}$/d' $ROCKSPEC
+   sed -i 's/\(   url = "[^"]*",\)/\1\n   tag = "v'$version'",/' $ROCKSPEC
    sed -i 's/program_version = "[^"]*"/program_version = "'$version'"/' src/luarocks/core/cfg.lua
    sed -i 's/vars.VERSION = "[0-9.]*"/vars.VERSION = "'$xyversion'"/' install.bat
    echo "==============================================================================="
@@ -89,6 +90,12 @@ grep -q "LuaRocks version $version" "configure" || {
 grep -q "\"$version-1\"" "$ROCKSPEC" || {
    echo
    echo "version in rockspec is incorrect. Please fix it."
+   exit 1
+}
+
+"$lua54dir/bin/lua" -e 'assert(loadfile("'$ROCKSPEC'"))' || {
+   echo
+   echo "$ROCKSPEC is not valid Lua. Please fix it."
    exit 1
 }
 


### PR DESCRIPTION
## Summary

The official `luarocks-3.13.0.tar.gz` on luarocks.org ships a syntactically invalid `luarocks-3.13.0-1.rockspec` (#1851):

```lua
source = {
   url = "git+https://github.com/luarocks/luarocks",
   tag = "v3.13.0"
   tag = "v3.12.2",
}
```

This breaks `make bootstrap` and every tool that installs LuaRocks from the official tarball (asdf, mise, etc.), since the rockspec fails `loadfile` on every Lua version with `'}' expected (to close '{' at line 4) near 'tag'`.

## Root cause

In `makedist`, the sed that sets the source tag *inserts* a new line after the `url` line — without a trailing comma, and without removing a pre-existing `tag` line:

```bash
sed -i 's/\(   url = "[^"]*",\)/\1\n   tag = "v'$version'"/' $ROCKSPEC
```

When a release is cut from a tree that carries the *previous release's* rockspec (which already has a `tag` line) rather than `luarocks-dev-1.rockspec` (which doesn't), the result is the duplicate-tag syntax error above. That's exactly what happened for 3.13.0: commit 31032c434b01c853e94ef21b8d9979436fbf81bc (the first "Release 3.13.0" commit, cut from a lineage carrying `luarocks-3.12.2-1.rockspec`) contains the broken rockspec, and the official tarball was built from that state. The rockspec was hand-fixed two minutes later in 3421bedc2ce2b64e79530bb97497531b014899a8 (the commit tagged `v3.13.0`), but the tarball was never re-rolled — which is why the GitHub release archive is fine while the luarocks.org tarball is broken.

## Fix

- Delete any existing `tag = ...` line before inserting the new one, so the substitution is correct for both the dev rockspec and a previous release's rockspec.
- Insert the new tag line with a trailing comma, matching the hand-fixed 3421bedc.
- Add a guard alongside the existing `grep -q` checks that validates the rockspec actually loads as Lua (using the Lua 5.4 prefix `makedist` already requires) before the tarball is packed — this would have caught #1851 before it shipped.

## Verification

Ran the new sed sequence against both input shapes:

- `luarocks-dev-1.rockspec` (no tag line) → valid rockspec, `loadfile` OK
- `luarocks-3.12.2-1.rockspec` (stale tag line, the 3.13.0 scenario) → valid rockspec, `loadfile` OK, byte-identical `source` table to the hand-fixed 3421bedc
- Old sed against the 3.12.2 rockspec reproduces the shipped corruption and the exact error reported in #1851; the new `loadfile` guard fails on it with exit 1.

## Note for maintainers

This PR only fixes the release tooling so it can't happen again. The broken `luarocks-3.13.0.tar.gz` itself lives on `gh-pages` with a PGP signature and a `source_digest` pinned in `releases.json`, so only a maintainer can re-roll, re-sign, and re-publish it (or publish a 3.13.1). Until then, 3.13.0 — the first release to support Lua 5.5 — remains uninstallable from the official tarball.

Fixes the tooling side of #1851.