### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,7 +506,7 @@ package.cpath as well
 
 > Released 06/Jun/2019
 
-This is another bugfix release, that incldes a couple of fixes,
+This is another bugfix release, that includes a couple of fixes,
 including better Lua detection, and fixes specific to MacOS and
 FreeBSD.
 
@@ -829,7 +829,7 @@ overhauled, making use of LuaRocks 3 features to greatly simplify them:
   in preparation for a stable public API.
 * Likewise, modules representing `luarocks-admin` commands were moved into the
   `luarocks.admin.cmd` namespace.
-* New internal objects for representing interaction with the repostories:
+* New internal objects for representing interaction with the repositories:
   `luarocks.queries` and `luarocks.results`
 * Type checking rules of file formats were moved into the `luarocks.type` namespace.
 

--- a/docs/config_file_format.md
+++ b/docs/config_file_format.md
@@ -52,7 +52,7 @@ order) for a user config file:
 * `external_deps_subdirs` (table with string keys and string values) -
   Subdirectories to be used in conjunction with external_deps_dirs. Specifies
   where to look for specific types external dependencies. This can be
-  overriden, for example, on Linux distributions which feature multiarch
+  overridden, for example, on Linux distributions which feature multiarch
   libraries and libraries are no longer in the "lib" subdir. Default is { bin
   = "bin", lib = "lib", include = "include" }.
 
@@ -216,7 +216,7 @@ To test this, add a line `dump_env()` to your config file and execute
   variables to ensure Lua modules are found. If set to false, scripts
   installed at bin/ are copied directly, and no wrappers are generated.
 
-* `use_extensions` (boolean) - If specified, rockspec format verison 1.1 is
+* `use_extensions` (boolean) - If specified, rockspec format version 1.1 is
   enabled, adding the deploy.wrap_bin_scripts option to the rockspec format,
   which acts like the wrap_bin_scripts option above, in a rock by rock basis.
 

--- a/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
+++ b/docs/creating_a_makefile_that_plays_nice_with_luarocks.md
@@ -117,7 +117,7 @@ where you can store configuration or other data for your module. Your code
 must be made aware of these paths in order to use them. If you use the
 `copy_directories` entry in the build section of your rockspec,
 then what is mentioned there is copied to $(PREFIX) (i.e. a directory doc
-will be available unter $(PREFIX)/doc). If you copy directories in your
+will be available under $(PREFIX)/doc). If you copy directories in your
 `install` Makefile rule, you should do the same.
 
 Now, if your Makefile is meant to be used standalone as well, which it

--- a/docs/installation_instructions_for_windows.md
+++ b/docs/installation_instructions_for_windows.md
@@ -37,7 +37,7 @@ MSVC compiler, `cl`, are set.
 
 The default settings are suitable for installing LuaRocks globally
 in your system while allowing both system-wide and per-user sets of rocks.
-Non-priviledged accounts will be able to install their own rocks in their
+Non-privileged accounts will be able to install their own rocks in their
 %APPDATA% directory, and administrator accounts can install rocks that
 will be available for everyone.
 
@@ -87,7 +87,7 @@ Other options:
 | /FORCECONFIG   | Use a single config location. Do not use the LUAROCKS_CONFIG variable or the user's home directory. Useful to avoid conflicts when LuaRocks is embedded |
 | /F             | Force. Remove installation directory if it already exists. |
 | /NOREG         | Do not load registry info to register '.rockspec' extension with LuaRocks commands (right-click). |
-| /NOADMIN       | The installer requires admin priviledges. If not available it will elevate a new process. Use this switch to prevent elevation, but make sure the destination paths are all accessible for the current user. |
+| /NOADMIN       | The installer requires admin privileges. If not available it will elevate a new process. Use this switch to prevent elevation, but make sure the destination paths are all accessible for the current user. |
 | /Q             | Do not prompt for confirmation of settings |
 
 After installation, a default config file called config.lua will be installed at the directory defined by /CONFIG. For further configuration of LuaRocks paths, see the [Config file format](config_file_format.md). For more information on the structure of rocks trees see [rocks repositories](rocks_repositories.md).

--- a/docs/paths_and_external_dependencies.md
+++ b/docs/paths_and_external_dependencies.md
@@ -35,9 +35,9 @@ itself is considered a special external dependency.
 
 These path variables are set in the global `variables` table defined in the
 [config file](config_file_format.md). Their values are populated automatically
-by LuaRocks, but can be overriden by the user (either by setting them directly
+by LuaRocks, but can be overridden by the user (either by setting them directly
 in the config file, or by passing them through the "luarocks" command line). 
 
 The `variables` table always contains entries for `LUA_BINDIR`, `LUA_INCDIR`
 and `LUA_LIBDIR`. Like the other external dependency variables, these can be
-overriden in the LuaRocks config file or in the command line.
+overridden in the LuaRocks config file or in the command line.

--- a/spec/unit/rockspecs_spec.lua
+++ b/spec/unit/rockspecs_spec.lua
@@ -34,7 +34,7 @@ describe("luarocks.rockspecs #unit", function()
       })
    end)
 
-   it("does not add a build dependency for non-vendored build type if it's already ther", function()
+   it("does not add a build dependency for non-vendored build type if it's already there", function()
       local filename = "test-1.0-1.rockspec"
       local rockspec = {
          package = "test",

--- a/src/luarocks/cmd.tl
+++ b/src/luarocks/cmd.tl
@@ -681,7 +681,7 @@ function cmd.run_command(description: string, commands: {string: string}, extern
       -- Fallback producing _some_ Lua configuration based on the running interpreter.
       -- Most likely won't produce correct results when running from the standalone binary,
       -- so eventually we need to drop this and outright fail if Lua is not found
-      -- or explictly configured
+      -- or explicitly configured
       if not cfg.variables.LUA then
          local first_arg = get_first_arg()
          local bin_dir = dir.dir_name(fs.absolute_name(first_arg))

--- a/src/luarocks/cmd/new_version.tl
+++ b/src/luarocks/cmd/new_version.tl
@@ -76,7 +76,7 @@ end
 
 -- Try to download source file using URL from a rockspec.
 -- If it specified MD5, update it.
--- @return true if no errors ocurred
+-- @return true if no errors occurred
 -- @return an error message in case of errors
 -- @return if no errors, a true boolean if the MD5 changed.
 local function check_url_and_update_md5(out_rs: Rockspec, invalid_is_error?: boolean): boolean, string, boolean

--- a/src/luarocks/core/cfg.d.tl
+++ b/src/luarocks/core/cfg.d.tl
@@ -26,7 +26,7 @@ local record cfg
    record cache
       luajit_version_checked: boolean
       luajit_version: string
-      rocks_provided: {string: string} --? right type? infered from src/luarocks/util
+      rocks_provided: {string: string} --? right type? inferred from src/luarocks/util
    end
 
    variables: {string: string}

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -435,7 +435,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
    end
 
    if platforms.msys then
-      -- msys is basically cygwin made out of mingw, meaning the subsytem is unixish
+      -- msys is basically cygwin made out of mingw, meaning the subsystem is unixish
       -- enough, yet we can freely mix with native win32
       defaults.external_deps_patterns = {
          bin = { "?.exe", "?.bat", "?" },

--- a/src/luarocks/core/util.tl
+++ b/src/luarocks/core/util.tl
@@ -40,7 +40,7 @@ end
 -- (in the case in which indent is composed by spaces or "--").
 -- Userdata and function keys and values are shown as strings,
 -- which logically are exactly not equivalent to the original code.
--- This routine can serve for pretty formating tables with
+-- This routine can serve for pretty formatting tables with
 -- proper indentations, apart from printing them:
 -- io.write(table.show(t, "t"))   -- a typical use
 -- Written by Julio Manuel Fernandez-Diaz,

--- a/src/luarocks/deps.tl
+++ b/src/luarocks/deps.tl
@@ -173,7 +173,7 @@ local function rock_status(dep: Query, get_versions: function(Query): {string}, 
    return installed and installed.." "..installation_type..": success" or "not installed"
 end
 
---- Check depenendencies of a package and report any missing ones.
+--- Check dependencies of a package and report any missing ones.
 -- @param name string: package name.
 -- @param version string: package version.
 -- @param dependencies table: array of dependencies.

--- a/src/luarocks/search.tl
+++ b/src/luarocks/search.tl
@@ -176,7 +176,7 @@ end
 
 --- Get the URL for the latest in a set of versions.
 -- @param name string: The package name to be used in the URL.
--- @param versions table: An array of version informations, as stored
+-- @param versions table: An array of version information, as stored
 -- in search result trees.
 -- @return string or nil: the URL for the latest version if one could
 -- be picked, or nil.


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=auxiliar,binar --skip="./vendor/*,./win32/*"`

% `codespell --ignore-words-list=auxiliar,binar --skip="./vendor/*,./win32/*" --write-changes` 