### PR TITLE
ci: Upgrade Windows OpenSSL from v3.6.2 to 3.6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,7 @@ jobs:
       # The following env variables
       # only applies to Visual Studio
       LUAROCKS_DEPS_DIR: c:\external
-      LUAROCKS_DEPS_OPENSSL_VER: "3.6.2"
+      LUAROCKS_DEPS_OPENSSL_VER: "3.6.3"
       LUAROCKS_DEPS_ZLIB_VER: "1.3.1"
       # The following env variable
       # applies to both Visual Studio and MinGW-w64


### PR DESCRIPTION
```diff
-     LUAROCKS_DEPS_OPENSSL_VER: "3.6.2"
+     LUAROCKS_DEPS_OPENSSL_VER: "3.6.3"
```
Fix `WindowsTests` failures found in the `Download OpenSSL installer` job step.
* https://github.com/luarocks/luarocks/actions/runs/28606791659/job/85072099389?pr=1888
>  $installerName = "D:\a\luarocks\luarocks\build\openssl-installer-3.6.2-x64.exe";
[7](https://github.com/luarocks/luarocks/actions/runs/28606791659/job/85072099389?pr=1888#step:14:108)
Exception: D:\a\_temp\2b717ea9-6118-491a-b67d-e709f7d54951.ps1:37
Line |
  37 |    throw "Installer not found for version ${version}. Please, update O …
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Installer not found for version 3.6.2. Please, update OpenSSL to the latest version found at
     | https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json
Error: Process completed with exit code 1.

[win32_openssl_hashes.json](https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json) does not contain `3.6.2` but does contain both `3.6.3` and `4.0.1`