### PR TITLE
ci: Add curl retry on zlib in binary/Makefile.windows

### DIFF
--- a/binary/Makefile.windows
+++ b/binary/Makefile.windows
@@ -46,7 +46,7 @@ $(WINDOWS_DEPS_DIR)/lib/libssl.a: $(BUILD_WINDOWS_DEPS_DIR)/openssl-$(OPENSSL_VE
 
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz:
 	mkdir -p $(@D)
-	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -OL https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
+	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -vOL --fail-with-body --retry 5 https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION): $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz
 	cd $(BUILD_WINDOWS_DEPS_DIR) && tar zxvpf zlib-$(ZLIB_VERSION).tar.gz
 $(WINDOWS_DEPS_DIR)/lib/libz.a: $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION)


### PR DESCRIPTION
Add cURL retry with exponential backoff for a file that occasionally causes CI to fail.
`-f` fails on errors instead of saving an error page which `tar` rejects (gzip: stdin: not in gzip format).
* https://curl.se/docs/manpage.html#--fail

`--retry 5` gives us 5 tries with exponential backoff.
* https://curl.se/docs/manpage.html#--retry

`binary/Makefile.windows`:
```diff
- curl -OL https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
+ curl -vOL --fail-with-body --retry 5 https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
```
Fixes the one failing GitHub Action test in: https://github.com/luarocks/luarocks/pull/1890/checks