### PR TITLE
lua5.5: loop control variables are const in quick_parse

### DIFF
--- a/spec/util/quick.lua
+++ b/spec/util/quick.lua
@@ -131,6 +131,7 @@ local function parse(filename)
    end
 
    for line in input:gmatch("([^\r\n]*)\r?\n?") do
+      local line = line
       cur_line = cur_line + 1
 
       local state = stack[#stack]


### PR DESCRIPTION
[Lua v5.5 docs](https://www.lua.org/manual/5.5/manual.html#8.1):
> The control variable in __for__ loops is read-only. If you need to change it, declare a local variable with the same name in the loop body. 

Discovered by running the tests on Lua v5.5 in:
* #1889 

Related to:
* #1844