### PR TITLE
refactor(zlib): use reliable GitHub URL to download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,7 +280,7 @@ jobs:
         if: ${{ matrix.COMPILER == 'vs' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
         run: |
           curl -o "${{ github.workspace }}\zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz" ^
-              "https://zlib.net/fossils/zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz"
+              "https://github.com/madler/zlib/releases/download/v${{ env.LUAROCKS_DEPS_ZLIB_VER }}/zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz"
 
       - name: Save zlib tarball
         if: ${{ matrix.COMPILER == 'vs' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}

--- a/binary/Makefile.windows
+++ b/binary/Makefile.windows
@@ -46,7 +46,7 @@ $(WINDOWS_DEPS_DIR)/lib/libssl.a: $(BUILD_WINDOWS_DEPS_DIR)/openssl-$(OPENSSL_VE
 
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz:
 	mkdir -p $(@D)
-	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -vOL --fail-with-body --retry 5 https://www.zlib.net/fossils/zlib-$(ZLIB_VERSION).tar.gz
+	cd $(BUILD_WINDOWS_DEPS_DIR) && curl -vOL --fail-with-body --retry 5 https://github.com/madler/zlib/releases/download/v$(ZLIB_VERSION)/zlib-$(ZLIB_VERSION).tar.gz
 $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION): $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION).tar.gz
 	cd $(BUILD_WINDOWS_DEPS_DIR) && tar zxvpf zlib-$(ZLIB_VERSION).tar.gz
 $(WINDOWS_DEPS_DIR)/lib/libz.a: $(BUILD_WINDOWS_DEPS_DIR)/zlib-$(ZLIB_VERSION)


### PR DESCRIPTION
switch to a reliable GitHub URL to fix intermittent issues: see [https://github.com/luarocks/luarocks/pull/1891](https://github.com/luarocks/luarocks/pull/1891)