### PR TITLE
detect and skip busybox wget (fixes #1712)

### DIFF
--- a/src/luarocks/fs/tools.lua
+++ b/src/luarocks/fs/tools.lua
@@ -13,10 +13,15 @@ local dir_stack = {}
 do
    local tool_cache = {}
 
+   local function wget_is_compatible()
+      -- busybox wget is incompatible and does not support -V
+      return fs.execute_quiet(vars.WGET .. " -V")
+   end
+
    local tool_options = {
       downloader = {
          desc = "downloader",
-         { var = "WGET", name = "wget" },
+         { var = "WGET", name = "wget", check_compat = wget_is_compatible },
          { var = "CURL", name = "curl" },
       },
       md5checker = {
@@ -27,13 +32,23 @@ do
       },
    }
 
+   local function is_available(opt)
+      if not fs.is_tool_available(vars[opt.var], opt.name) then
+         return false
+      end
+      if opt.check_compat then
+         return opt.check_compat()
+      end
+      return true
+   end
+
    function tools.which_tool(tooltype)
       local tool = tool_cache[tooltype]
       local names = {}
       if not tool then
          for _, opt in ipairs(tool_options[tooltype]) do
             table.insert(names, opt.name)
-            if fs.is_tool_available(vars[opt.var], opt.name) then
+            if is_available(opt) then
                tool = opt
                tool_cache[tooltype] = opt
                break

--- a/src/luarocks/upload/api.lua
+++ b/src/luarocks/upload/api.lua
@@ -183,7 +183,7 @@ if not ltn12_ok then
    api.Api.request = function(self, url, params, post_params, extra_headers)
       local vars = cfg.variables
 
-      if fs.which_tool("downloader") == "wget" then
+      do
          local curl_ok, err = fs.is_tool_available(vars.CURL, "curl")
          if not curl_ok then
             return nil, err

--- a/src/luarocks/upload/api.tl
+++ b/src/luarocks/upload/api.tl
@@ -183,7 +183,7 @@ if not ltn12_ok then -- If not using LuaSocket and/or LuaSec...
    api.Api.request = function(self: Api, url: string, params?: Parameters, post_params?: Parameters, extra_headers?: Parameters): {string : any}, string
       local vars = cfg.variables
 
-      if fs.which_tool("downloader") == "wget" then
+      do
          local curl_ok, err = fs.is_tool_available(vars.CURL, "curl")
          if not curl_ok then
             return nil, err


### PR DESCRIPTION
I started using Alpine micro-VMs and hit that bug.

A workaround in the meantime is setting `variables.WGET = "IDoNotExist"` in `luarocks/config-5.X.lua`.