### PR TITLE
fix(ci): use `-L` flag with `curl` to follow redirects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Download zlib
         if: ${{ matrix.COMPILER == 'vs' && steps.restore-zlib-tarball.outputs.cache-hit != 'true' }}
         run: |
-          curl -o "${{ github.workspace }}\zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz" ^
+          curl -Lo "${{ github.workspace }}\zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz" ^
               "https://github.com/madler/zlib/releases/download/v${{ env.LUAROCKS_DEPS_ZLIB_VER }}/zlib-${{ env.LUAROCKS_DEPS_ZLIB_VER }}.tar.gz"
 
       - name: Save zlib tarball
@@ -436,7 +436,7 @@ jobs:
           }
 
           # Download the installer
-          curl "--create-dirs" "-o" "${installerName}" "${installerUrl}";
+          curl "--create-dirs" "-Lo" "${installerName}" "${installerUrl}";
 
           # Validate sha512 checksum
           $downloadedHash = Get-FileHash -Path "${installerName}" -Algorithm "SHA512" |


### PR DESCRIPTION
## Description

Fixes the download of artifacts with `curl` by adding `-L` flag to follow redirects. At the moment, it was downloading an empty tarball for zlib, and thus CI is failing.

> [!IMPORTANT]
> 
> The actions cache were poisoned by empty cache entries for `zlib` tarball due the lack of `-L` flag to follow redirects. I deleted such poisoned entries manually to test these changes (I did it on my fork and it worked).