### PR TITLE
ci: Use recommended way to detect the operating system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,11 @@ jobs:
         luaRocksVersion: "3.13.0"
 
     - name: 'Setup macOS deps'
-      if: ${{ contains(matrix.os, 'macos') }}
+      if: runner.os == 'macOS'
       run: brew install openssl bzip2
 
     - name: 'Setup Ubuntu deps'
-      if: ${{ contains(matrix.os, 'ubuntu') }}
+      if: runner.os == 'Linux'
       run: sudo apt-get install libbz2-dev
 
     - name: Prep


### PR DESCRIPTION
GitHub Actions docs: [`Detecting the operating system`](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#detecting-the-operating-system)