### PR TITLE
Upgrade deps compat53 and luacov for lua5.5 compatibility

### DIFF
--- a/spec/show_spec.lua
+++ b/spec/show_spec.lua
@@ -46,12 +46,12 @@ describe("luarocks show #integration", function()
 
       it("rockspec of luacov", function()
          local output = run.luarocks("show --rockspec luacov")
-         assert.is.truthy(output:match("luacov--0.15.0--1.rockspec"))
+         assert.is.truthy(output:match("luacov--0.17.0--1.rockspec"))
       end)
 
       it("mversion of luacov", function()
          local output = run.luarocks("show --mversion luacov")
-         assert.is.truthy(output:match("0.15.0--1"))
+         assert.is.truthy(output:match("0.17.0--1"))
       end)
 
       it("rock tree of luacov", function()

--- a/spec/util/test_env.lua
+++ b/spec/util/test_env.lua
@@ -1151,8 +1151,10 @@ function test_env.main()
    end
 
    -- luacov is needed for both minimal or full environment
+   table.insert(urls, "/datafile-${DATAFILE}.src.rock")
    table.insert(urls, "/luacov-${LUACOV}.src.rock")
    table.insert(urls, "/cluacov-${CLUACOV}.src.rock")
+   table.insert(rocks, "datafile")
    table.insert(rocks, "luacov")
    table.insert(rocks, "cluacov")
 

--- a/spec/util/versions.lua
+++ b/spec/util/versions.lua
@@ -1,13 +1,14 @@
 return {
    binaryheap = "0.4-1", -- dependency for copas
    bit32 = "5.3.5.1-1", -- dependency for luaposix on Lua 5.1
-   cluacov = "0.1.3-1",
-   compat53 = "0.14.3-1",
+   cluacov = "1.0.0-1",
+   compat53 = "0.15.1-1",
    copas = "3.0.0-2",
    cprint = "0.2-1",
+   datafile = "0.11-1",
    dkjson = "2.6-1",
    lpeg = "1.0.0-1",
-   luacov = "0.15.0-1",
+   luacov = "0.17.0-1",
    luafilesystem = "1.8.0-1",
    luafilesystem_old = "1.6.3-2",
    luaposix = "35.1-1",


### PR DESCRIPTION
A subset of:
* #1889 

These dependency upgrades are necessary but not sufficient for successfully running our CI tests on lua5.5.
* [ ] https://luarocks.org/modules/lunarmodules/compat53
* [ ] https://luarocks.org/modules/lunarmodules/luacov
* [ ] https://luarocks.org/modules/lunarmodules/cluacov
* [ ] https://luarocks.org/modules/hisham/datafile
