### PR TITLE
download_with_mirrors: Safely build errors with falsely names

### DIFF
--- a/src/luarocks/fetch.lua
+++ b/src/luarocks/fetch.lua
@@ -141,7 +141,7 @@ local function download_with_mirrors(url, filename, cache, servers)
       if name then
          return name, nil, nil, from_cache
       else
-         err = err .. name .. "\n"
+         err = err .. tostring(name) .. "\n"
       end
    end
 

--- a/src/luarocks/fetch.tl
+++ b/src/luarocks/fetch.tl
@@ -141,7 +141,7 @@ local function download_with_mirrors(url: string, filename: string, cache: boole
       if name then
          return name, nil, nil, from_cache
       else
-         err = err .. name .. "\n"
+         err = err .. tostring(name) .. "\n"
       end
    end
 


### PR DESCRIPTION
The variable `name` must be falsely in this `else` clause so stringify values like `false`,  `nil `,  `{}`, etc., so we can safely build an `err` message instead of merely crashing.
* #1828
* #1829