### PR TITLE
Upgrade lua-bz2 for lua5.5 compatibility

### DIFF
--- a/binary/all_in_one
+++ b/binary/all_in_one
@@ -466,7 +466,7 @@ local function main()
       luasocket = "./binary/luasocket-3.1.0-1.rockspec",
       luasec = "./binary/luasec-1.3.2-1.rockspec",
       ["lua-zlib"] = "./binary/lua-zlib-1.4-0.rockspec",
-      ["lua-bz2"] = "./binary/lua-bz2-0.2.1-1.rockspec",
+      ["lua-bz2"] = "./binary/lua-bz2-0.2.2-1.rockspec",
       luaposix = if_platform("unix", "./binary/luaposix-35.1-1.rockspec"),
       luafilesystem = "luafilesystem",
    }

--- a/binary/lua-bz2-0.2.2-1.rockspec
+++ b/binary/lua-bz2-0.2.2-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-bz2"
-version = "0.2.1-1"
+version = "0.2.2-1"
 source = {
    url = "git+https://github.com/hishamhm/lua-bz2.git",
-   tag = "0.2.1",
+   tag = "0.2.2",
 }
 description = {
    summary = "A Lua binding to Julian Seward's libbzip2",


### PR DESCRIPTION
Fixes #1910 
* #1910 

A subset of:
* #1889 

The lua-bz2 dependency upgrade is necessary but not sufficient for successfully running our CI tests on lua5.5.
* [x] https://github.com/hishamhm/lua-bz2